### PR TITLE
Use smithy fetch HTTP Handler

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -17,10 +17,7 @@ import { HttpHandlerOptions } from "@aws-sdk/types";
 import { buildQueryString } from "@aws-sdk/querystring-builder";
 import { requestTimeout } from "@aws-sdk/fetch-http-handler/dist-es/request-timeout";
 
-import {
-	FetchHttpHandler,
-	FetchHttpHandlerOptions,
-} from "@aws-sdk/fetch-http-handler";
+import { FetchHttpHandler } from "@smithy/fetch-http-handler";
 
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 import * as crypto from "crypto";
@@ -305,7 +302,7 @@ export default class S3UploaderPlugin extends Plugin {
 					},
 					endpoint: apiEndpoint,
 					forcePathStyle: this.settings.forcePathStyle,
-					requestHandler: new ObsHttpHandler(),
+					requestHandler: new ObsHttpHandler({ keepAlive: false}),
 				});
 			} else {
 				this.s3 = new S3Client({
@@ -315,7 +312,8 @@ export default class S3UploaderPlugin extends Plugin {
 						secretAccessKey: this.settings.secretKey,
 					},
 					endpoint: apiEndpoint,
-					forcePathStyle: this.settings.forcePathStyle
+					forcePathStyle: this.settings.forcePathStyle,
+					requestHandler: new ObsHttpHandler({ keepAlive: false}),
 				});
 		}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,12 @@
 			"version": "0.2.5",
 			"license": "MIT",
 			"dependencies": {
-				"@aws-sdk/client-s3": "^3.241.0",
+				"@aws-sdk/client-s3": "3.317.0",
 				"@aws-sdk/fetch-http-handler": "^3.310.0",
 				"@aws-sdk/protocol-http": "^3.310.0",
 				"@aws-sdk/querystring-builder": "^3.310.0",
-				"@aws-sdk/types": "^3.310.0"
+				"@aws-sdk/types": "^3.310.0",
+				"@smithy/fetch-http-handler": "^2.2.7"
 			},
 			"devDependencies": {
 				"@types/mime-types": "^2.1.1",
@@ -31,12 +32,12 @@
 			}
 		},
 		"node_modules/@aws-crypto/crc32": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
-			"integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+			"integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
 			"dependencies": {
-				"@aws-crypto/util": "^2.0.0",
-				"@aws-sdk/types": "^3.1.0",
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
 				"tslib": "^1.11.1"
 			}
 		},
@@ -46,12 +47,12 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@aws-crypto/crc32c": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-2.0.0.tgz",
-			"integrity": "sha512-vF0eMdMHx3O3MoOXUfBZry8Y4ZDtcuskjjKgJz8YfIDjLStxTZrYXk+kZqtl6A0uCmmiN/Eb/JbC/CndTV1MHg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-3.0.0.tgz",
+			"integrity": "sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==",
 			"dependencies": {
-				"@aws-crypto/util": "^2.0.0",
-				"@aws-sdk/types": "^3.1.0",
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
 				"tslib": "^1.11.1"
 			}
 		},
@@ -61,9 +62,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@aws-crypto/ie11-detection": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
-			"integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+			"integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
 			"dependencies": {
 				"tslib": "^1.11.1"
 			}
@@ -74,13 +75,14 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@aws-crypto/sha1-browser": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-2.0.0.tgz",
-			"integrity": "sha512-3fIVRjPFY8EG5HWXR+ZJZMdWNRpwbxGzJ9IH9q93FpbgCH8u8GHRi46mZXp3cYD7gealmyqpm3ThZwLKJjWJhA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-3.0.0.tgz",
+			"integrity": "sha512-NJth5c997GLHs6nOYTzFKTbYdMNA6/1XlKVgnZoaZcQ7z7UJlOgj2JdbHE8tiYLS3fzXNCguct77SPGat2raSw==",
 			"dependencies": {
-				"@aws-crypto/ie11-detection": "^2.0.0",
-				"@aws-crypto/supports-web-crypto": "^2.0.0",
-				"@aws-sdk/types": "^3.1.0",
+				"@aws-crypto/ie11-detection": "^3.0.0",
+				"@aws-crypto/supports-web-crypto": "^3.0.0",
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
 				"@aws-sdk/util-locate-window": "^3.0.0",
 				"@aws-sdk/util-utf8-browser": "^3.0.0",
 				"tslib": "^1.11.1"
@@ -92,15 +94,15 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@aws-crypto/sha256-browser": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
-			"integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+			"integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
 			"dependencies": {
-				"@aws-crypto/ie11-detection": "^2.0.0",
-				"@aws-crypto/sha256-js": "^2.0.0",
-				"@aws-crypto/supports-web-crypto": "^2.0.0",
-				"@aws-crypto/util": "^2.0.0",
-				"@aws-sdk/types": "^3.1.0",
+				"@aws-crypto/ie11-detection": "^3.0.0",
+				"@aws-crypto/sha256-js": "^3.0.0",
+				"@aws-crypto/supports-web-crypto": "^3.0.0",
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
 				"@aws-sdk/util-locate-window": "^3.0.0",
 				"@aws-sdk/util-utf8-browser": "^3.0.0",
 				"tslib": "^1.11.1"
@@ -112,12 +114,12 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@aws-crypto/sha256-js": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-			"integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+			"integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
 			"dependencies": {
-				"@aws-crypto/util": "^2.0.0",
-				"@aws-sdk/types": "^3.1.0",
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
 				"tslib": "^1.11.1"
 			}
 		},
@@ -127,9 +129,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@aws-crypto/supports-web-crypto": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
-			"integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+			"integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
 			"dependencies": {
 				"tslib": "^1.11.1"
 			}
@@ -140,11 +142,11 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@aws-crypto/util": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
-			"integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+			"integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
 			"dependencies": {
-				"@aws-sdk/types": "^3.110.0",
+				"@aws-sdk/types": "^3.222.0",
 				"@aws-sdk/util-utf8-browser": "^3.0.0",
 				"tslib": "^1.11.1"
 			}
@@ -155,764 +157,499 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@aws-sdk/abort-controller": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
-			"integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.310.0.tgz",
+			"integrity": "sha512-v1zrRQxDLA1MdPim159Vx/CPHqsB4uybSxRi1CnfHO5ZjHryx3a5htW2gdGAykVCul40+yJXvfpufMrELVxH+g==",
 			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/abort-controller/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/abort-controller/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/chunked-blob-reader": {
-			"version": "3.188.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.188.0.tgz",
-			"integrity": "sha512-zkPRFZZPL3eH+kH86LDYYXImiClA1/sW60zYOjse9Pgka+eDJlvBN6hcYxwDEKjcwATYiSRR1aVQHcfCinlGXg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.310.0.tgz",
+			"integrity": "sha512-CrJS3exo4mWaLnWxfCH+w88Ou0IcAZSIkk4QbmxiHl/5Dq705OLoxf4385MVyExpqpeVJYOYQ2WaD8i/pQZ2fg==",
 			"dependencies": {
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
 			}
 		},
-		"node_modules/@aws-sdk/chunked-blob-reader-native": {
-			"version": "3.208.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.208.0.tgz",
-			"integrity": "sha512-JeOZ95PW+fJ6bbuqPySYqLqHk1n4+4ueEEraJsiUrPBV0S1ZtyvOGHcnGztKUjr2PYNaiexmpWuvUve9K12HRA==",
-			"dependencies": {
-				"@aws-sdk/util-base64": "3.208.0",
-				"tslib": "^2.3.1"
-			}
+		"node_modules/@aws-sdk/chunked-blob-reader/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/client-s3": {
-			"version": "3.241.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.241.0.tgz",
-			"integrity": "sha512-GxkiX4f+FUW2Lr3PySc1wuYlfU8QV2nx6KlBY8L8yf2txtajEL0/hhfo5Pbo4Uw1ZZlTv4iPHUOiTrm2R9Rhyg==",
+			"version": "3.317.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.317.0.tgz",
+			"integrity": "sha512-Y7AZMO/ikKFARsGYv7LKNELTDqJHjEpDTGEBBWnFkVoTmlquBsa9r0tU2nofP3uxSIkySPkkQpR50Zm/Q6zWyw==",
 			"dependencies": {
-				"@aws-crypto/sha1-browser": "2.0.0",
-				"@aws-crypto/sha256-browser": "2.0.0",
-				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/client-sts": "3.241.0",
-				"@aws-sdk/config-resolver": "3.234.0",
-				"@aws-sdk/credential-provider-node": "3.241.0",
-				"@aws-sdk/eventstream-serde-browser": "3.226.0",
-				"@aws-sdk/eventstream-serde-config-resolver": "3.226.0",
-				"@aws-sdk/eventstream-serde-node": "3.226.0",
-				"@aws-sdk/fetch-http-handler": "3.226.0",
-				"@aws-sdk/hash-blob-browser": "3.226.0",
-				"@aws-sdk/hash-node": "3.226.0",
-				"@aws-sdk/hash-stream-node": "3.226.0",
-				"@aws-sdk/invalid-dependency": "3.226.0",
-				"@aws-sdk/md5-js": "3.226.0",
-				"@aws-sdk/middleware-bucket-endpoint": "3.226.0",
-				"@aws-sdk/middleware-content-length": "3.226.0",
-				"@aws-sdk/middleware-endpoint": "3.226.0",
-				"@aws-sdk/middleware-expect-continue": "3.226.0",
-				"@aws-sdk/middleware-flexible-checksums": "3.226.0",
-				"@aws-sdk/middleware-host-header": "3.226.0",
-				"@aws-sdk/middleware-location-constraint": "3.226.0",
-				"@aws-sdk/middleware-logger": "3.226.0",
-				"@aws-sdk/middleware-recursion-detection": "3.226.0",
-				"@aws-sdk/middleware-retry": "3.235.0",
-				"@aws-sdk/middleware-sdk-s3": "3.231.0",
-				"@aws-sdk/middleware-serde": "3.226.0",
-				"@aws-sdk/middleware-signing": "3.226.0",
-				"@aws-sdk/middleware-ssec": "3.226.0",
-				"@aws-sdk/middleware-stack": "3.226.0",
-				"@aws-sdk/middleware-user-agent": "3.226.0",
-				"@aws-sdk/node-config-provider": "3.226.0",
-				"@aws-sdk/node-http-handler": "3.226.0",
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/signature-v4-multi-region": "3.226.0",
-				"@aws-sdk/smithy-client": "3.234.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/url-parser": "3.226.0",
-				"@aws-sdk/util-base64": "3.208.0",
-				"@aws-sdk/util-body-length-browser": "3.188.0",
-				"@aws-sdk/util-body-length-node": "3.208.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.234.0",
-				"@aws-sdk/util-defaults-mode-node": "3.234.0",
-				"@aws-sdk/util-endpoints": "3.241.0",
-				"@aws-sdk/util-retry": "3.229.0",
-				"@aws-sdk/util-stream-browser": "3.226.0",
-				"@aws-sdk/util-stream-node": "3.226.0",
-				"@aws-sdk/util-user-agent-browser": "3.226.0",
-				"@aws-sdk/util-user-agent-node": "3.226.0",
-				"@aws-sdk/util-utf8-browser": "3.188.0",
-				"@aws-sdk/util-utf8-node": "3.208.0",
-				"@aws-sdk/util-waiter": "3.226.0",
-				"@aws-sdk/xml-builder": "3.201.0",
-				"fast-xml-parser": "4.0.11",
-				"tslib": "^2.3.1"
+				"@aws-crypto/sha1-browser": "3.0.0",
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/client-sts": "3.316.0",
+				"@aws-sdk/config-resolver": "3.310.0",
+				"@aws-sdk/credential-provider-node": "3.316.0",
+				"@aws-sdk/eventstream-serde-browser": "3.310.0",
+				"@aws-sdk/eventstream-serde-config-resolver": "3.310.0",
+				"@aws-sdk/eventstream-serde-node": "3.310.0",
+				"@aws-sdk/fetch-http-handler": "3.310.0",
+				"@aws-sdk/hash-blob-browser": "3.310.0",
+				"@aws-sdk/hash-node": "3.310.0",
+				"@aws-sdk/hash-stream-node": "3.310.0",
+				"@aws-sdk/invalid-dependency": "3.310.0",
+				"@aws-sdk/md5-js": "3.310.0",
+				"@aws-sdk/middleware-bucket-endpoint": "3.310.0",
+				"@aws-sdk/middleware-content-length": "3.310.0",
+				"@aws-sdk/middleware-endpoint": "3.310.0",
+				"@aws-sdk/middleware-expect-continue": "3.310.0",
+				"@aws-sdk/middleware-flexible-checksums": "3.310.0",
+				"@aws-sdk/middleware-host-header": "3.310.0",
+				"@aws-sdk/middleware-location-constraint": "3.310.0",
+				"@aws-sdk/middleware-logger": "3.310.0",
+				"@aws-sdk/middleware-recursion-detection": "3.310.0",
+				"@aws-sdk/middleware-retry": "3.310.0",
+				"@aws-sdk/middleware-sdk-s3": "3.310.0",
+				"@aws-sdk/middleware-serde": "3.310.0",
+				"@aws-sdk/middleware-signing": "3.310.0",
+				"@aws-sdk/middleware-ssec": "3.310.0",
+				"@aws-sdk/middleware-stack": "3.310.0",
+				"@aws-sdk/middleware-user-agent": "3.310.0",
+				"@aws-sdk/node-config-provider": "3.310.0",
+				"@aws-sdk/node-http-handler": "3.310.0",
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/signature-v4-multi-region": "3.310.0",
+				"@aws-sdk/smithy-client": "3.316.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/url-parser": "3.310.0",
+				"@aws-sdk/util-base64": "3.310.0",
+				"@aws-sdk/util-body-length-browser": "3.310.0",
+				"@aws-sdk/util-body-length-node": "3.310.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.316.0",
+				"@aws-sdk/util-defaults-mode-node": "3.316.0",
+				"@aws-sdk/util-endpoints": "3.310.0",
+				"@aws-sdk/util-retry": "3.310.0",
+				"@aws-sdk/util-stream-browser": "3.310.0",
+				"@aws-sdk/util-stream-node": "3.310.0",
+				"@aws-sdk/util-user-agent-browser": "3.310.0",
+				"@aws-sdk/util-user-agent-node": "3.310.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"@aws-sdk/util-waiter": "3.310.0",
+				"@aws-sdk/xml-builder": "3.310.0",
+				"fast-xml-parser": "4.1.2",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/fetch-http-handler": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
-			"integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
-			"dependencies": {
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/querystring-builder": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-base64": "3.208.0",
-				"tslib": "^2.3.1"
-			}
-		},
-		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/protocol-http": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-			"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/querystring-builder": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
-			"integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-uri-escape": "3.201.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/client-s3/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/client-sso": {
-			"version": "3.241.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.241.0.tgz",
-			"integrity": "sha512-Jm4HR+RYAqKMEYZvvWaq0NYUKKonyInOeubObXH4BLXZpmUBSdYCSjjLdNJY3jkQoxbDVPVMIurVNh5zT5SMRw==",
+			"version": "3.316.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.316.0.tgz",
+			"integrity": "sha512-wGXfIhR0lJGB8QTT0fwSwwklHePHxd2GW3IQt3trXnEYe0frmJ7vYRnVL5CSRKsikLDmaU7ll3SdsshMzQzo3w==",
 			"dependencies": {
-				"@aws-crypto/sha256-browser": "2.0.0",
-				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/config-resolver": "3.234.0",
-				"@aws-sdk/fetch-http-handler": "3.226.0",
-				"@aws-sdk/hash-node": "3.226.0",
-				"@aws-sdk/invalid-dependency": "3.226.0",
-				"@aws-sdk/middleware-content-length": "3.226.0",
-				"@aws-sdk/middleware-endpoint": "3.226.0",
-				"@aws-sdk/middleware-host-header": "3.226.0",
-				"@aws-sdk/middleware-logger": "3.226.0",
-				"@aws-sdk/middleware-recursion-detection": "3.226.0",
-				"@aws-sdk/middleware-retry": "3.235.0",
-				"@aws-sdk/middleware-serde": "3.226.0",
-				"@aws-sdk/middleware-stack": "3.226.0",
-				"@aws-sdk/middleware-user-agent": "3.226.0",
-				"@aws-sdk/node-config-provider": "3.226.0",
-				"@aws-sdk/node-http-handler": "3.226.0",
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/smithy-client": "3.234.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/url-parser": "3.226.0",
-				"@aws-sdk/util-base64": "3.208.0",
-				"@aws-sdk/util-body-length-browser": "3.188.0",
-				"@aws-sdk/util-body-length-node": "3.208.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.234.0",
-				"@aws-sdk/util-defaults-mode-node": "3.234.0",
-				"@aws-sdk/util-endpoints": "3.241.0",
-				"@aws-sdk/util-retry": "3.229.0",
-				"@aws-sdk/util-user-agent-browser": "3.226.0",
-				"@aws-sdk/util-user-agent-node": "3.226.0",
-				"@aws-sdk/util-utf8-browser": "3.188.0",
-				"@aws-sdk/util-utf8-node": "3.208.0",
-				"tslib": "^2.3.1"
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/config-resolver": "3.310.0",
+				"@aws-sdk/fetch-http-handler": "3.310.0",
+				"@aws-sdk/hash-node": "3.310.0",
+				"@aws-sdk/invalid-dependency": "3.310.0",
+				"@aws-sdk/middleware-content-length": "3.310.0",
+				"@aws-sdk/middleware-endpoint": "3.310.0",
+				"@aws-sdk/middleware-host-header": "3.310.0",
+				"@aws-sdk/middleware-logger": "3.310.0",
+				"@aws-sdk/middleware-recursion-detection": "3.310.0",
+				"@aws-sdk/middleware-retry": "3.310.0",
+				"@aws-sdk/middleware-serde": "3.310.0",
+				"@aws-sdk/middleware-stack": "3.310.0",
+				"@aws-sdk/middleware-user-agent": "3.310.0",
+				"@aws-sdk/node-config-provider": "3.310.0",
+				"@aws-sdk/node-http-handler": "3.310.0",
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/smithy-client": "3.316.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/url-parser": "3.310.0",
+				"@aws-sdk/util-base64": "3.310.0",
+				"@aws-sdk/util-body-length-browser": "3.310.0",
+				"@aws-sdk/util-body-length-node": "3.310.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.316.0",
+				"@aws-sdk/util-defaults-mode-node": "3.316.0",
+				"@aws-sdk/util-endpoints": "3.310.0",
+				"@aws-sdk/util-retry": "3.310.0",
+				"@aws-sdk/util-user-agent-browser": "3.310.0",
+				"@aws-sdk/util-user-agent-node": "3.310.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/client-sso-oidc": {
-			"version": "3.241.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.241.0.tgz",
-			"integrity": "sha512-/Ml2QBGpGfUEeBrPzBZhSTBkHuXFD2EAZEIHGCBH4tKaURDI6/FoGI8P1Rl4BzoFt+II/Cr91Eox6YT9EwChsQ==",
+			"version": "3.316.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.316.0.tgz",
+			"integrity": "sha512-e2fvC7o42YV+LcZYfXCcvBn4L7NM9oNccnZ7T+pS6SFpHZlaqkw4uuQMRE6iUAof+Id7Mt7xDrz1x2yGlP+8GA==",
 			"dependencies": {
-				"@aws-crypto/sha256-browser": "2.0.0",
-				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/config-resolver": "3.234.0",
-				"@aws-sdk/fetch-http-handler": "3.226.0",
-				"@aws-sdk/hash-node": "3.226.0",
-				"@aws-sdk/invalid-dependency": "3.226.0",
-				"@aws-sdk/middleware-content-length": "3.226.0",
-				"@aws-sdk/middleware-endpoint": "3.226.0",
-				"@aws-sdk/middleware-host-header": "3.226.0",
-				"@aws-sdk/middleware-logger": "3.226.0",
-				"@aws-sdk/middleware-recursion-detection": "3.226.0",
-				"@aws-sdk/middleware-retry": "3.235.0",
-				"@aws-sdk/middleware-serde": "3.226.0",
-				"@aws-sdk/middleware-stack": "3.226.0",
-				"@aws-sdk/middleware-user-agent": "3.226.0",
-				"@aws-sdk/node-config-provider": "3.226.0",
-				"@aws-sdk/node-http-handler": "3.226.0",
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/smithy-client": "3.234.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/url-parser": "3.226.0",
-				"@aws-sdk/util-base64": "3.208.0",
-				"@aws-sdk/util-body-length-browser": "3.188.0",
-				"@aws-sdk/util-body-length-node": "3.208.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.234.0",
-				"@aws-sdk/util-defaults-mode-node": "3.234.0",
-				"@aws-sdk/util-endpoints": "3.241.0",
-				"@aws-sdk/util-retry": "3.229.0",
-				"@aws-sdk/util-user-agent-browser": "3.226.0",
-				"@aws-sdk/util-user-agent-node": "3.226.0",
-				"@aws-sdk/util-utf8-browser": "3.188.0",
-				"@aws-sdk/util-utf8-node": "3.208.0",
-				"tslib": "^2.3.1"
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/config-resolver": "3.310.0",
+				"@aws-sdk/fetch-http-handler": "3.310.0",
+				"@aws-sdk/hash-node": "3.310.0",
+				"@aws-sdk/invalid-dependency": "3.310.0",
+				"@aws-sdk/middleware-content-length": "3.310.0",
+				"@aws-sdk/middleware-endpoint": "3.310.0",
+				"@aws-sdk/middleware-host-header": "3.310.0",
+				"@aws-sdk/middleware-logger": "3.310.0",
+				"@aws-sdk/middleware-recursion-detection": "3.310.0",
+				"@aws-sdk/middleware-retry": "3.310.0",
+				"@aws-sdk/middleware-serde": "3.310.0",
+				"@aws-sdk/middleware-stack": "3.310.0",
+				"@aws-sdk/middleware-user-agent": "3.310.0",
+				"@aws-sdk/node-config-provider": "3.310.0",
+				"@aws-sdk/node-http-handler": "3.310.0",
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/smithy-client": "3.316.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/url-parser": "3.310.0",
+				"@aws-sdk/util-base64": "3.310.0",
+				"@aws-sdk/util-body-length-browser": "3.310.0",
+				"@aws-sdk/util-body-length-node": "3.310.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.316.0",
+				"@aws-sdk/util-defaults-mode-node": "3.316.0",
+				"@aws-sdk/util-endpoints": "3.310.0",
+				"@aws-sdk/util-retry": "3.310.0",
+				"@aws-sdk/util-user-agent-browser": "3.310.0",
+				"@aws-sdk/util-user-agent-node": "3.310.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/fetch-http-handler": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
-			"integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
-			"dependencies": {
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/querystring-builder": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-base64": "3.208.0",
-				"tslib": "^2.3.1"
-			}
+		"node_modules/@aws-sdk/client-sso-oidc/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
-		"node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/protocol-http": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-			"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/querystring-builder": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
-			"integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-uri-escape": "3.201.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/fetch-http-handler": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
-			"integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
-			"dependencies": {
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/querystring-builder": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-base64": "3.208.0",
-				"tslib": "^2.3.1"
-			}
-		},
-		"node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/protocol-http": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-			"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/querystring-builder": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
-			"integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-uri-escape": "3.201.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/client-sso/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/client-sts": {
-			"version": "3.241.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.241.0.tgz",
-			"integrity": "sha512-vmlG8cJzRf8skCtTJbA2wBvD2c3NQ5gZryzJvTKDS06KzBzcEpnjlLseuTekcnOiRNekbFUX5hRu5Zj3N2ReLg==",
+			"version": "3.316.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.316.0.tgz",
+			"integrity": "sha512-5SD59+DRVy1mKckGs/5J8OwWpRS3E5v4BX19XaX/s9JJ5Rw9aZd9DP4SZVpeNXztIPjkQSEzHgrUVlZFB1QJgg==",
 			"dependencies": {
-				"@aws-crypto/sha256-browser": "2.0.0",
-				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/config-resolver": "3.234.0",
-				"@aws-sdk/credential-provider-node": "3.241.0",
-				"@aws-sdk/fetch-http-handler": "3.226.0",
-				"@aws-sdk/hash-node": "3.226.0",
-				"@aws-sdk/invalid-dependency": "3.226.0",
-				"@aws-sdk/middleware-content-length": "3.226.0",
-				"@aws-sdk/middleware-endpoint": "3.226.0",
-				"@aws-sdk/middleware-host-header": "3.226.0",
-				"@aws-sdk/middleware-logger": "3.226.0",
-				"@aws-sdk/middleware-recursion-detection": "3.226.0",
-				"@aws-sdk/middleware-retry": "3.235.0",
-				"@aws-sdk/middleware-sdk-sts": "3.226.0",
-				"@aws-sdk/middleware-serde": "3.226.0",
-				"@aws-sdk/middleware-signing": "3.226.0",
-				"@aws-sdk/middleware-stack": "3.226.0",
-				"@aws-sdk/middleware-user-agent": "3.226.0",
-				"@aws-sdk/node-config-provider": "3.226.0",
-				"@aws-sdk/node-http-handler": "3.226.0",
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/smithy-client": "3.234.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/url-parser": "3.226.0",
-				"@aws-sdk/util-base64": "3.208.0",
-				"@aws-sdk/util-body-length-browser": "3.188.0",
-				"@aws-sdk/util-body-length-node": "3.208.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.234.0",
-				"@aws-sdk/util-defaults-mode-node": "3.234.0",
-				"@aws-sdk/util-endpoints": "3.241.0",
-				"@aws-sdk/util-retry": "3.229.0",
-				"@aws-sdk/util-user-agent-browser": "3.226.0",
-				"@aws-sdk/util-user-agent-node": "3.226.0",
-				"@aws-sdk/util-utf8-browser": "3.188.0",
-				"@aws-sdk/util-utf8-node": "3.208.0",
-				"fast-xml-parser": "4.0.11",
-				"tslib": "^2.3.1"
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/config-resolver": "3.310.0",
+				"@aws-sdk/credential-provider-node": "3.316.0",
+				"@aws-sdk/fetch-http-handler": "3.310.0",
+				"@aws-sdk/hash-node": "3.310.0",
+				"@aws-sdk/invalid-dependency": "3.310.0",
+				"@aws-sdk/middleware-content-length": "3.310.0",
+				"@aws-sdk/middleware-endpoint": "3.310.0",
+				"@aws-sdk/middleware-host-header": "3.310.0",
+				"@aws-sdk/middleware-logger": "3.310.0",
+				"@aws-sdk/middleware-recursion-detection": "3.310.0",
+				"@aws-sdk/middleware-retry": "3.310.0",
+				"@aws-sdk/middleware-sdk-sts": "3.310.0",
+				"@aws-sdk/middleware-serde": "3.310.0",
+				"@aws-sdk/middleware-signing": "3.310.0",
+				"@aws-sdk/middleware-stack": "3.310.0",
+				"@aws-sdk/middleware-user-agent": "3.310.0",
+				"@aws-sdk/node-config-provider": "3.310.0",
+				"@aws-sdk/node-http-handler": "3.310.0",
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/smithy-client": "3.316.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/url-parser": "3.310.0",
+				"@aws-sdk/util-base64": "3.310.0",
+				"@aws-sdk/util-body-length-browser": "3.310.0",
+				"@aws-sdk/util-body-length-node": "3.310.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.316.0",
+				"@aws-sdk/util-defaults-mode-node": "3.316.0",
+				"@aws-sdk/util-endpoints": "3.310.0",
+				"@aws-sdk/util-retry": "3.310.0",
+				"@aws-sdk/util-user-agent-browser": "3.310.0",
+				"@aws-sdk/util-user-agent-node": "3.310.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"fast-xml-parser": "4.1.2",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/fetch-http-handler": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
-			"integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
-			"dependencies": {
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/querystring-builder": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-base64": "3.208.0",
-				"tslib": "^2.3.1"
-			}
-		},
-		"node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/protocol-http": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-			"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/querystring-builder": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
-			"integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-uri-escape": "3.201.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/client-sts/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/config-resolver": {
-			"version": "3.234.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
-			"integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.310.0.tgz",
+			"integrity": "sha512-8vsT+/50lOqfDxka9m/rRt6oxv1WuGZoP8oPMk0Dt+TxXMbAzf4+rejBgiB96wshI1k3gLokYRjSQZn+dDtT8g==",
 			"dependencies": {
-				"@aws-sdk/signature-v4": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-config-provider": "3.208.0",
-				"@aws-sdk/util-middleware": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-config-provider": "3.310.0",
+				"@aws-sdk/util-middleware": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/config-resolver/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/config-resolver/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
-			"integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.310.0.tgz",
+			"integrity": "sha512-vvIPQpI16fj95xwS7M3D48F7QhZJBnnCgB5lR+b7So+vsG9ibm1mZRVGzVpdxCvgyOhHFbvrby9aalNJmmIP1A==",
 			"dependencies": {
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/property-provider": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/credential-provider-env/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/credential-provider-imds": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
-			"integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.310.0.tgz",
+			"integrity": "sha512-baxK7Zp6dai5AGW01FIW27xS2KAaPUmKLIXv5SvFYsUgXXvNW55im4uG3b+2gA0F7V+hXvVBH08OEqmwW6we5w==",
 			"dependencies": {
-				"@aws-sdk/node-config-provider": "3.226.0",
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/url-parser": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/node-config-provider": "3.310.0",
+				"@aws-sdk/property-provider": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/url-parser": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/credential-provider-imds/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/credential-provider-imds/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.241.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.241.0.tgz",
-			"integrity": "sha512-CI+mu6h74Kzmscw35TvNkc/wYHsHPGAwP7humSHoWw53H9mVw21Ggft/dT1iFQQZWQ8BNXkzuXlNo1IlqwMgOA==",
+			"version": "3.316.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.316.0.tgz",
+			"integrity": "sha512-ZADkpdEjFCAXyzEpYbCRENlZ/AQEwevWdPd2yshjNo7xvOcepv4pPIBpYd8h9LvRafSLGA7zlWDz84hkIt+HKA==",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "3.226.0",
-				"@aws-sdk/credential-provider-imds": "3.226.0",
-				"@aws-sdk/credential-provider-process": "3.226.0",
-				"@aws-sdk/credential-provider-sso": "3.241.0",
-				"@aws-sdk/credential-provider-web-identity": "3.226.0",
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/shared-ini-file-loader": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/credential-provider-env": "3.310.0",
+				"@aws-sdk/credential-provider-imds": "3.310.0",
+				"@aws-sdk/credential-provider-process": "3.310.0",
+				"@aws-sdk/credential-provider-sso": "3.316.0",
+				"@aws-sdk/credential-provider-web-identity": "3.310.0",
+				"@aws-sdk/property-provider": "3.310.0",
+				"@aws-sdk/shared-ini-file-loader": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.241.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.241.0.tgz",
-			"integrity": "sha512-08zPQcD5o9brQmzEipWHeHgU85aQcEF8MWLfpeyjO6e1/l7ysQ35NsS+PYtv77nLpGCx/X+ZuW/KXWoRrbw77w==",
+			"version": "3.316.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.316.0.tgz",
+			"integrity": "sha512-oE1LTXP8XZp4bT8LhBeolMRiz0RwnmHDC2XpUmWO8LTmbDNrQO0mVzxEvXDLeKaN5BIFIJqNFlMgjWUMa9Kwcw==",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "3.226.0",
-				"@aws-sdk/credential-provider-imds": "3.226.0",
-				"@aws-sdk/credential-provider-ini": "3.241.0",
-				"@aws-sdk/credential-provider-process": "3.226.0",
-				"@aws-sdk/credential-provider-sso": "3.241.0",
-				"@aws-sdk/credential-provider-web-identity": "3.226.0",
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/shared-ini-file-loader": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/credential-provider-env": "3.310.0",
+				"@aws-sdk/credential-provider-imds": "3.310.0",
+				"@aws-sdk/credential-provider-ini": "3.316.0",
+				"@aws-sdk/credential-provider-process": "3.310.0",
+				"@aws-sdk/credential-provider-sso": "3.316.0",
+				"@aws-sdk/credential-provider-web-identity": "3.310.0",
+				"@aws-sdk/property-provider": "3.310.0",
+				"@aws-sdk/shared-ini-file-loader": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/credential-provider-node/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
-			"integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.310.0.tgz",
+			"integrity": "sha512-h73sg6GPMUWC+3zMCbA1nZ2O03nNJt7G96JdmnantiXBwHpRKWW8nBTLzx5uhXn6hTuTaoQRP/P+oxQJKYdMmA==",
 			"dependencies": {
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/shared-ini-file-loader": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/property-provider": "3.310.0",
+				"@aws-sdk/shared-ini-file-loader": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/credential-provider-process/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.241.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.241.0.tgz",
-			"integrity": "sha512-6Bjd6eEIrVomRTrPrM4dlxusQm+KMJ9hLYKECCpFkwDKIK+pTgZNLRtQdalHyzwneHJPdimrm8cOv1kUQ8hPoA==",
+			"version": "3.316.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.316.0.tgz",
+			"integrity": "sha512-8/O2twlsoV1bDkZ9jd7JCMWsftfyoTyRT1UYscsKZGUDEgZRAxRkzS3GLYuLXEWNuxb1OB9rYk/cEJoxwy7T9g==",
 			"dependencies": {
-				"@aws-sdk/client-sso": "3.241.0",
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/shared-ini-file-loader": "3.226.0",
-				"@aws-sdk/token-providers": "3.241.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/client-sso": "3.316.0",
+				"@aws-sdk/property-provider": "3.310.0",
+				"@aws-sdk/shared-ini-file-loader": "3.310.0",
+				"@aws-sdk/token-providers": "3.316.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/credential-provider-sso/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
-			"integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.310.0.tgz",
+			"integrity": "sha512-H4SzuZXILNhK6/IR1uVvsUDZvzc051hem7GLyYghBCu8mU+tq28YhKE8MfSroi6eL2e5Vujloij1OM2EQQkPkw==",
 			"dependencies": {
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/property-provider": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/eventstream-codec": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.226.0.tgz",
-			"integrity": "sha512-6uPtR8vSwz3fqoZk9hrb6qBYdp3PJ22+JxV5Wimdesvow4kJXSgDQXIxEkxbv6SxB9tNRB4uJHD84RetHEi15Q==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.310.0.tgz",
+			"integrity": "sha512-clIeSgWbZbxwtsxZ/yoedNM0/kJFSIjjHPikuDGhxhqc+vP6TN3oYyVMFrYwFaTFhk2+S5wZcWYMw8Op1pWo+A==",
 			"dependencies": {
-				"@aws-crypto/crc32": "2.0.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-hex-encoding": "3.201.0",
-				"tslib": "^2.3.1"
+				"@aws-crypto/crc32": "3.0.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-hex-encoding": "3.310.0",
+				"tslib": "^2.5.0"
 			}
 		},
-		"node_modules/@aws-sdk/eventstream-codec/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/eventstream-codec/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/eventstream-serde-browser": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.226.0.tgz",
-			"integrity": "sha512-otYC5aZE9eJUqAlKpy8w0rPDQ1eKGvZPtgxWXmFYSO2lDVGfI1nBBNmdZ4MdHqNuQ7ucsKMQYF8BFJ65K2tYPA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.310.0.tgz",
+			"integrity": "sha512-3S6ziuQVALgEyz0TANGtYDVeG8ArK4Y05mcgrs8qUTmsvlDIXX37cR/DvmVbNB76M4IrsZeSAIajL9644CywkA==",
 			"dependencies": {
-				"@aws-sdk/eventstream-serde-universal": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/eventstream-serde-universal": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/eventstream-serde-browser/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/eventstream-serde-browser/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/eventstream-serde-config-resolver": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.226.0.tgz",
-			"integrity": "sha512-A56Gypg+lyEfA5cna+EUH9XTrj0SvRG1gwNW7lrUzviN36SeA/LFTUIOEjxVML3Lowy+EPAcrSZ67h6aepoAig==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.310.0.tgz",
+			"integrity": "sha512-8s1Qdn9STj+sV75nUp9yt0W6fHS4BZ2jTm4Z/1Pcbvh2Gqs0WjH5n2StS+pDW5Y9J/HSGBl0ogmUr5lC5bXFHg==",
 			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/eventstream-serde-config-resolver/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/eventstream-serde-config-resolver/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/eventstream-serde-node": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.226.0.tgz",
-			"integrity": "sha512-KWLnKkKDzI9RNkiK6OiSYpG/XjZfue6Bsp/vRG+H5z3fbXdHv4X2+iW+Efu2Kvn7jsUyUv82TCl57DyJ/HKYhQ==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.310.0.tgz",
+			"integrity": "sha512-kSnRomCgW43K9TmQYuwN9+AoYPnhyOKroanUMyZEzJk7rpCPMj4OzaUpXfDYOvznFNYn7NLaH6nHLJAr0VPlJA==",
 			"dependencies": {
-				"@aws-sdk/eventstream-serde-universal": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/eventstream-serde-universal": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/eventstream-serde-node/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/eventstream-serde-node/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/eventstream-serde-universal": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.226.0.tgz",
-			"integrity": "sha512-Q8viYM1Sv90/yIUqyWNeG1GEvyVlAI3GIrInQcCMC+xT59jS+IKGy2y7ojCvSWXnhf5/HMXKcmG092QsqeKy0Q==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.310.0.tgz",
+			"integrity": "sha512-Qyjt5k/waV5cDukpgT824ISZAz5U0pwzLz5ztR409u85AGNkF/9n7MS+LSyBUBSb0WJ5pUeSD47WBk+nLq9Nhw==",
 			"dependencies": {
-				"@aws-sdk/eventstream-codec": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/eventstream-codec": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/eventstream-serde-universal/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/eventstream-serde-universal/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/fetch-http-handler": {
 			"version": "3.310.0",
@@ -926,7 +663,78 @@
 				"tslib": "^2.5.0"
 			}
 		},
-		"node_modules/@aws-sdk/fetch-http-handler/node_modules/@aws-sdk/is-array-buffer": {
+		"node_modules/@aws-sdk/fetch-http-handler/node_modules/tslib": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+		},
+		"node_modules/@aws-sdk/hash-blob-browser": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.310.0.tgz",
+			"integrity": "sha512-OoR8p0cbypToysLT0v3o2oyjy6+DKrY7GNCAzHOHJK9xmqXCt+DsjKoPeiY7o1sWX2aN6Plmvubj/zWxMKEn/A==",
+			"dependencies": {
+				"@aws-sdk/chunked-blob-reader": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@aws-sdk/hash-blob-browser/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/hash-node": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.310.0.tgz",
+			"integrity": "sha512-NvE2fhRc8GRwCXBfDehxVAWCmVwVMILliAKVPAEr4yz2CkYs0tqU51S48x23dtna07H4qHtgpeNqVTthcIQOEQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-buffer-from": "3.310.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/hash-node/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/hash-stream-node": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.310.0.tgz",
+			"integrity": "sha512-ZoXdybNgvMz1Hl6k/e32xVL3jmG5p2IEk5mTtLfFEuskTJ74Z+VMYKkkF1whyy7KQfH83H+TQGnsGtlRCchQKw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/hash-stream-node/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/invalid-dependency": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.310.0.tgz",
+			"integrity": "sha512-1s5RG5rSPXoa/aZ/Kqr5U/7lqpx+Ry81GprQ2bxWqJvWQIJ0IRUwo5pk8XFxbKVr/2a+4lZT/c3OGoBOM1yRRA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@aws-sdk/invalid-dependency/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/is-array-buffer": {
 			"version": "3.310.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
 			"integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
@@ -937,819 +745,398 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/fetch-http-handler/node_modules/@aws-sdk/util-base64": {
-			"version": "3.310.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-			"integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-			"dependencies": {
-				"@aws-sdk/util-buffer-from": "3.310.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/fetch-http-handler/node_modules/@aws-sdk/util-buffer-from": {
-			"version": "3.310.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-			"integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-			"dependencies": {
-				"@aws-sdk/is-array-buffer": "3.310.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/fetch-http-handler/node_modules/tslib": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-		},
-		"node_modules/@aws-sdk/hash-blob-browser": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.226.0.tgz",
-			"integrity": "sha512-5DCvWE6L4xGoViEHyjcPFuUe1G2EtNx8TqswWaoaKgyasP/yuRm4H99Ra7rqIrjCcSTAGD9NVsUQvVVw1bGt9w==",
-			"dependencies": {
-				"@aws-sdk/chunked-blob-reader": "3.188.0",
-				"@aws-sdk/chunked-blob-reader-native": "3.208.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
-			}
-		},
-		"node_modules/@aws-sdk/hash-blob-browser/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/hash-node": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
-			"integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-buffer-from": "3.208.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/hash-node/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/hash-stream-node": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.226.0.tgz",
-			"integrity": "sha512-cgNTGlF8SdHaQXtjEmuLXz2U8SLM2JDKtIVPku/lHTMsUsEn+fuv2C+h1f/hvd4aNw5t1zggym7sO1/h/rv56Q==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/hash-stream-node/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/invalid-dependency": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
-			"integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
-			}
-		},
-		"node_modules/@aws-sdk/invalid-dependency/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/is-array-buffer": {
-			"version": "3.201.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-			"integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/is-array-buffer/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/md5-js": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.226.0.tgz",
-			"integrity": "sha512-ENigJRNudqyh6xsch166SZ4gggHd3XzZJ8gkCU4CWPne04HcR3BkWSO774IuWooCHt8zkaEHKecPurRz6qR+Vw==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.310.0.tgz",
+			"integrity": "sha512-x5sRBUrEfLWAS1EhwbbDQ7cXq6uvBxh3qR2XAsnGvFFceTeAadk7cVogWxlk3PC+OCeeym7c3/6Bv2HQ2f1YyQ==",
 			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-utf8-browser": "3.188.0",
-				"@aws-sdk/util-utf8-node": "3.208.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"tslib": "^2.5.0"
 			}
 		},
-		"node_modules/@aws-sdk/md5-js/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/md5-js/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/middleware-bucket-endpoint": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.226.0.tgz",
-			"integrity": "sha512-A1Vq5W2X7jgTfjqcKPmjoHohF0poP+9fxwL97fQMvzcwmjhtoCV3bLEpo6CGYx0pKPiSlRJXZkRwRPj2hDHDmA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.310.0.tgz",
+			"integrity": "sha512-uJJfHI7v4AgbJZRLtyI8ap2QRWkBokGc3iyUoQ+dVNT3/CE2ZCu694A6W+H0dRqg79dIE+f9CRNdtLGa/Ehhvg==",
 			"dependencies": {
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-arn-parser": "3.208.0",
-				"@aws-sdk/util-config-provider": "3.208.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-arn-parser": "3.310.0",
+				"@aws-sdk/util-config-provider": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/protocol-http": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-			"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/middleware-content-length": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
-			"integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.310.0.tgz",
+			"integrity": "sha512-P8tQZxgDt6CAh1wd/W6WPzjc+uWPJwQkm+F7rAwRlM+k9q17HrhnksGDKcpuuLyIhPQYdmOMIkpKVgXGa4avhQ==",
 			"dependencies": {
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/middleware-content-length/node_modules/@aws-sdk/protocol-http": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-			"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-content-length/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/middleware-content-length/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/middleware-endpoint": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
-			"integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.310.0.tgz",
+			"integrity": "sha512-Z+N2vOL8K354/lstkClxLLsr6hCpVRh+0tCMXrVj66/NtKysCEZ/0b9LmqOwD9pWHNiI2mJqXwY0gxNlKAroUg==",
 			"dependencies": {
-				"@aws-sdk/middleware-serde": "3.226.0",
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/signature-v4": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/url-parser": "3.226.0",
-				"@aws-sdk/util-config-provider": "3.208.0",
-				"@aws-sdk/util-middleware": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/middleware-serde": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/url-parser": "3.310.0",
+				"@aws-sdk/util-middleware": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/protocol-http": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-			"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/middleware-endpoint/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/middleware-expect-continue": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.226.0.tgz",
-			"integrity": "sha512-YxvQKTV/eA9P8AgW0hXOgj5Qa+TSnNFfyOkfeP089aP3f6p92b1cESf33TEOKsddive2mHT5LRCN6MuPcgWWrA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.310.0.tgz",
+			"integrity": "sha512-l3d1z2gt+gINJDnPSyu84IxfzjzPfCQrqC1sunw2cZGo/sXtEiq698Q3SiTcO2PGP4LBQAy2RHb5wVBJP708CQ==",
 			"dependencies": {
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/protocol-http": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-			"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/middleware-expect-continue/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/middleware-flexible-checksums": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.226.0.tgz",
-			"integrity": "sha512-8A9Ot9A7794UP5tMGl2MnfTW/UM/jYy1wRWF9YkR/hPIcPb7OmE0hmlwIQGzb/7grxpYw66ETKf0WeH/41YfeQ==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.310.0.tgz",
+			"integrity": "sha512-5ndnLgzgGVpWkmHBAiYkagHqiSuow8q62J4J6E2PzaQ77+fm8W3nfdy7hK5trHokEyouCZdxT/XK/IRhgj/4PA==",
 			"dependencies": {
-				"@aws-crypto/crc32": "2.0.0",
-				"@aws-crypto/crc32c": "2.0.0",
-				"@aws-sdk/is-array-buffer": "3.201.0",
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-crypto/crc32": "3.0.0",
+				"@aws-crypto/crc32c": "3.0.0",
+				"@aws-sdk/is-array-buffer": "3.310.0",
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/protocol-http": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-			"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/middleware-host-header": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
-			"integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.310.0.tgz",
+			"integrity": "sha512-QWSA+46/hXorXyWa61ic2K7qZzwHTiwfk2e9mRRjeIRepUgI3qxFjsYqrWtrOGBjmFmq0pYIY8Bb/DCJuQqcoA==",
 			"dependencies": {
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/middleware-host-header/node_modules/@aws-sdk/protocol-http": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-			"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-host-header/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/middleware-host-header/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/middleware-location-constraint": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.226.0.tgz",
-			"integrity": "sha512-qHiYaBYPc2R37KxG2uqsUUwh4usrQMHfGkrpTUnx5d4rGzM3mC+muPsTpSHnAL63K2/yJOHQJFjss3GGwV4SSA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.310.0.tgz",
+			"integrity": "sha512-LFm0JTQWwTPWL/tZU2wsQTl8J5PpDEkXjEhaXVKamtyH0xhysRqd+0n92n65dc8oztAuQkb9xUbErGn5b6gsew==",
 			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/middleware-location-constraint/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/middleware-location-constraint/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/middleware-logger": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
-			"integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.310.0.tgz",
+			"integrity": "sha512-Lurm8XofrASBRnAVtiSNuDSRsRqPNg27RIFLLsLp/pqog9nFJ0vz0kgdb9S5Z+zw83Mm+UlqOe6D8NTUNp4fVg==",
 			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/middleware-logger/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/middleware-logger/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/middleware-recursion-detection": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
-			"integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.310.0.tgz",
+			"integrity": "sha512-SuB75/xk/gyue24gkriTwO2jFd7YcUGZDClQYuRejgbXSa3CO0lWyawQtfLcSSEBp9izrEVXuFH24K1eAft5nQ==",
 			"dependencies": {
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@aws-sdk/protocol-http": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-			"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/middleware-retry": {
-			"version": "3.235.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
-			"integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.310.0.tgz",
+			"integrity": "sha512-oTPsRy2W4s+dfxbJPW7Km+hHtv/OMsNsVfThAq8DDYKC13qlr1aAyOqGLD+dpBy2aKe7ss517Sy2HcHtHqm7/g==",
 			"dependencies": {
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/service-error-classification": "3.229.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-middleware": "3.226.0",
-				"@aws-sdk/util-retry": "3.229.0",
-				"tslib": "^2.3.1",
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/service-error-classification": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-middleware": "3.310.0",
+				"@aws-sdk/util-retry": "3.310.0",
+				"tslib": "^2.5.0",
 				"uuid": "^8.3.2"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/middleware-retry/node_modules/@aws-sdk/protocol-http": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-			"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-retry/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-retry/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
+		"node_modules/@aws-sdk/middleware-retry/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/middleware-sdk-s3": {
-			"version": "3.231.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.231.0.tgz",
-			"integrity": "sha512-UGaSvevd2TanfKgStF46dDSHkh4bxOr1gdUkyHm9i+1pF5lx4KdbnBZv/5SKnn7XifhHRXrs1M3lTzemXREhTA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.310.0.tgz",
+			"integrity": "sha512-QK9x9g2ksg0hOjjYgqddeFcn5ctUEGdxJVu4OumPXceulefMcSO2jyH2qTybYSA93nqNQFdFmg5wQfvIRUWFCQ==",
 			"dependencies": {
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-arn-parser": "3.208.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-arn-parser": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/protocol-http": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-			"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/middleware-sdk-s3/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/middleware-sdk-sts": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
-			"integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.310.0.tgz",
+			"integrity": "sha512-+5PFwlYNLvLLIfw0ASAoWV/iIF8Zv6R6QGtyP0CclhRSvNjgbQDVnV0g95MC5qvh+GB/Yjlkt8qAjLSPjHfsrQ==",
 			"dependencies": {
-				"@aws-sdk/middleware-signing": "3.226.0",
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/signature-v4": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/middleware-signing": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/protocol-http": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-			"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/middleware-sdk-sts/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/middleware-serde": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
-			"integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.310.0.tgz",
+			"integrity": "sha512-RNeeTVWSLTaentUeCgQKZhAl+C6hxtwD78cQWS10UymWpQFwbaxztzKUu4UQS5xA2j6PxwPRRUjqa4jcFjfLsg==",
 			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/middleware-serde/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/middleware-serde/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/middleware-signing": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
-			"integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.310.0.tgz",
+			"integrity": "sha512-f9mKq+XMdW207Af3hKjdTnpNhdtwqWuvFs/ZyXoOkp/g1MY1O6L23Jy6i52m29LxbT4AuNRG1oKODfXM0vYVjQ==",
 			"dependencies": {
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/signature-v4": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-middleware": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/property-provider": "3.310.0",
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/signature-v4": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-middleware": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/protocol-http": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-			"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/middleware-signing/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/middleware-ssec": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.226.0.tgz",
-			"integrity": "sha512-DR97oWoLHiMdaUP/wu99HtzG7/ijvCrjZGDH37WBO1rxFtEti6L7T09wgHzwxMN8gtL8FJA7dU8IrffGSC9VmA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.310.0.tgz",
+			"integrity": "sha512-CnEwNKVpd5bXnrCKPaePF8mWTA9ET21OMBb54y9b0fd8K02zoOcdBz4DWfh1SjFD4HkgCdja4egd8l2ivyvqmw==",
 			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/middleware-ssec/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/middleware-ssec/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/middleware-stack": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
-			"integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.310.0.tgz",
+			"integrity": "sha512-010O1PD+UAcZVKRvqEusE1KJqN96wwrf6QsqbRM0ywsKQ21NDweaHvEDlds2VHpgmofxkRLRu/IDrlPkKRQrRg==",
 			"dependencies": {
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
+		},
+		"node_modules/@aws-sdk/middleware-stack/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
-			"integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.310.0.tgz",
+			"integrity": "sha512-x3IOwSwSbwKidlxRk3CNVHVUb06SRuaELxggCaR++QVI8NU6qD/l4VHXKVRvbTHiC/cYxXE/GaBDgQVpDR7V/g==",
 			"dependencies": {
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-endpoints": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/protocol-http": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-			"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/middleware-user-agent/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/node-config-provider": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
-			"integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.310.0.tgz",
+			"integrity": "sha512-T/Pp6htc6hq/Cq+MLNDSyiwWCMVF6GqbBbXKVlO5L8rdHx4sq9xPdoPveZhGWrxvkanjA6eCwUp6E0riBOSVng==",
 			"dependencies": {
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/shared-ini-file-loader": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/property-provider": "3.310.0",
+				"@aws-sdk/shared-ini-file-loader": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/node-config-provider/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/node-config-provider/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/node-http-handler": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
-			"integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.310.0.tgz",
+			"integrity": "sha512-irv9mbcM9xC2xYjArQF5SYmHBMu4ciMWtGsoHII1nRuFOl9FoT4ffTvEPuLlfC6pznzvKt9zvnm6xXj7gDChKg==",
 			"dependencies": {
-				"@aws-sdk/abort-controller": "3.226.0",
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/querystring-builder": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/abort-controller": "3.310.0",
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/querystring-builder": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/node-http-handler/node_modules/@aws-sdk/protocol-http": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-			"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/node-http-handler/node_modules/@aws-sdk/querystring-builder": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
-			"integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-uri-escape": "3.201.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/node-http-handler/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/node-http-handler/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/property-provider": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
-			"integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.310.0.tgz",
+			"integrity": "sha512-3lxDb0akV6BBzmFe4nLPaoliQbAifyWJhuvuDOu7e8NzouvpQXs0275w9LePhhcgjKAEVXUIse05ZW2DLbxo/g==",
 			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/property-provider/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/property-provider/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/protocol-http": {
 			"version": "3.310.0",
@@ -1781,102 +1168,79 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/querystring-builder/node_modules/@aws-sdk/util-uri-escape": {
-			"version": "3.310.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-			"integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
-			"dependencies": {
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
 		"node_modules/@aws-sdk/querystring-builder/node_modules/tslib": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
 			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
 		},
 		"node_modules/@aws-sdk/querystring-parser": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
-			"integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.310.0.tgz",
+			"integrity": "sha512-YkIznoP6lsiIUHinx++/lbb3tlMURGGqMpo0Pnn32zYzGrJXA6eC3D0as2EcMjo55onTfuLcIiX4qzXes2MYOA==",
 			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/querystring-parser/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/querystring-parser/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/service-error-classification": {
-			"version": "3.229.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
-			"integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.310.0.tgz",
+			"integrity": "sha512-PuyC7k3qfIKeH2LCnDwbttMOKq3qAx4buvg0yfnJtQOz6t1AR8gsnAq0CjKXXyfkXwNKWTqCpE6lVNUIkXgsMw==",
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/shared-ini-file-loader": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
-			"integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.310.0.tgz",
+			"integrity": "sha512-N0q9pG0xSjQwc690YQND5bofm+4nfUviQ/Ppgan2kU6aU0WUq8KwgHJBto/YEEI+VlrME30jZJnxtOvcZJc2XA==",
 			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/shared-ini-file-loader/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/shared-ini-file-loader/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/signature-v4": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
-			"integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.310.0.tgz",
+			"integrity": "sha512-1M60P1ZBNAjCFv9sYW29OF6okktaeibWyW3lMXqzoHF70lHBZh+838iUchznXUA5FLabfn4jBFWMRxlAXJUY2Q==",
 			"dependencies": {
-				"@aws-sdk/is-array-buffer": "3.201.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-hex-encoding": "3.201.0",
-				"@aws-sdk/util-middleware": "3.226.0",
-				"@aws-sdk/util-uri-escape": "3.201.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/is-array-buffer": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-hex-encoding": "3.310.0",
+				"@aws-sdk/util-middleware": "3.310.0",
+				"@aws-sdk/util-uri-escape": "3.310.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/signature-v4-multi-region": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.226.0.tgz",
-			"integrity": "sha512-QHxNuf9ynK208v7Y3imdsa3Cz8ynYV7ZOf3sBJdItuEtHN6uy/KxaOrtvpF8I5Hyn48Hc8z5miTSMujFKT7GEw==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.310.0.tgz",
+			"integrity": "sha512-q8W+RIomTS/q85Ntgks/CoDElwqkC9+4OCicee5YznNHjQ4gtNWhUkYIyIRWRmXa/qx/AUreW9DM8FAecCOdng==",
 			"dependencies": {
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/signature-v4": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-arn-parser": "3.208.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/signature-v4": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
@@ -1890,89 +1254,53 @@
 				}
 			}
 		},
-		"node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/protocol-http": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-			"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/signature-v4-multi-region/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
-		"node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/signature-v4/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/signature-v4/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/smithy-client": {
-			"version": "3.234.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
-			"integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
+			"version": "3.316.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.316.0.tgz",
+			"integrity": "sha512-6YXOKbRnXeS8r8RWzuL6JMBolDYM5Wa4fD/VY6x/wK78i2xErHOvqzHgyyeLI1MMw4uqyd4wRNJNWC9TMPduXw==",
 			"dependencies": {
-				"@aws-sdk/middleware-stack": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/middleware-stack": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/smithy-client/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/smithy-client/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.241.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.241.0.tgz",
-			"integrity": "sha512-79okvuOS7V559OIL/RalIPG98wzmWxeFOChFnbEjn2pKOyGQ6FJRwLPYZaVRtNdAtnkBNgRpmFq9dX843QxhtQ==",
+			"version": "3.316.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.316.0.tgz",
+			"integrity": "sha512-foJ2YmB8A/mtp52riO2zdmBgzA3IpASNgUhY9FZg1BKpGcjqLQDGYP+BY3BA0H7CFsMa4PCf13M5wWwn1onyBA==",
 			"dependencies": {
-				"@aws-sdk/client-sso-oidc": "3.241.0",
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/shared-ini-file-loader": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/client-sso-oidc": "3.316.0",
+				"@aws-sdk/property-provider": "3.310.0",
+				"@aws-sdk/shared-ini-file-loader": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/token-providers/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/types": {
 			"version": "3.310.0",
@@ -1991,337 +1319,313 @@
 			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
 		},
 		"node_modules/@aws-sdk/url-parser": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
-			"integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.310.0.tgz",
+			"integrity": "sha512-mCLnCaSB9rQvAgx33u0DujLvr4d5yEm/W5r789GblwwQnlNXedVu50QRizMLTpltYWyAUoXjJgQnJHmJMaKXhw==",
 			"dependencies": {
-				"@aws-sdk/querystring-parser": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/querystring-parser": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			}
 		},
-		"node_modules/@aws-sdk/url-parser/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/url-parser/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/util-arn-parser": {
-			"version": "3.208.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.208.0.tgz",
-			"integrity": "sha512-QV4af+kscova9dv4VuHOgH8wEr/IIYHDGcnyVtkUEqahCejWr1Kuk+SBK0xMwnZY5LSycOtQ8aeqHOn9qOjZtA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.310.0.tgz",
+			"integrity": "sha512-jL8509owp/xB9+Or0pvn3Fe+b94qfklc2yPowZZIFAkFcCSIdkIglz18cPDWnYAcy9JGewpMS1COXKIUhZkJsA==",
 			"dependencies": {
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
+		},
+		"node_modules/@aws-sdk/util-arn-parser/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/util-base64": {
-			"version": "3.208.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
-			"integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+			"integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
 			"dependencies": {
-				"@aws-sdk/util-buffer-from": "3.208.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/util-buffer-from": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
+		},
+		"node_modules/@aws-sdk/util-base64/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/util-body-length-browser": {
-			"version": "3.188.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-			"integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+			"integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
 			"dependencies": {
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
 			}
+		},
+		"node_modules/@aws-sdk/util-body-length-browser/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/util-body-length-node": {
-			"version": "3.208.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
-			"integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+			"integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
 			"dependencies": {
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
+		},
+		"node_modules/@aws-sdk/util-body-length-node/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/util-buffer-from": {
-			"version": "3.208.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-			"integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+			"integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
 			"dependencies": {
-				"@aws-sdk/is-array-buffer": "3.201.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/is-array-buffer": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
+		},
+		"node_modules/@aws-sdk/util-buffer-from/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/util-config-provider": {
-			"version": "3.208.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-			"integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+			"integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
 			"dependencies": {
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
+		},
+		"node_modules/@aws-sdk/util-config-provider/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/util-defaults-mode-browser": {
-			"version": "3.234.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
-			"integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
+			"version": "3.316.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.316.0.tgz",
+			"integrity": "sha512-6FSqLhYmaihtH2n1s4b2rlLW0ABU8N6VZIfzLfe2ING4PF0MzfaMMhnTFUHVXfKCVGoR8yP6iyFTRCyHGVEL1w==",
 			"dependencies": {
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
+				"@aws-sdk/property-provider": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
 				"bowser": "^2.11.0",
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">= 10.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/util-defaults-mode-browser/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/util-defaults-mode-browser/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/util-defaults-mode-node": {
-			"version": "3.234.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
-			"integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
+			"version": "3.316.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.316.0.tgz",
+			"integrity": "sha512-dkYy10hdjPSScXXvnjGpZpnJxllkb6ICHgLMwZ4JczLHhPM12T/4PQ758YN8HS+muiYDGX1Bl2z1jd/bMcewBQ==",
 			"dependencies": {
-				"@aws-sdk/config-resolver": "3.234.0",
-				"@aws-sdk/credential-provider-imds": "3.226.0",
-				"@aws-sdk/node-config-provider": "3.226.0",
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/config-resolver": "3.310.0",
+				"@aws-sdk/credential-provider-imds": "3.310.0",
+				"@aws-sdk/node-config-provider": "3.310.0",
+				"@aws-sdk/property-provider": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">= 10.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/util-defaults-mode-node/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.241.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.241.0.tgz",
-			"integrity": "sha512-jVf8bKrN22Ey0xLmj75sL7EUvm5HFpuOMkXsZkuXycKhCwLBcEUWlvtJYtRjOU1zScPQv9GMJd2QXQglp34iOQ==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.310.0.tgz",
+			"integrity": "sha512-zG+/d/O5KPmAaeOMPd6bW1abifdT0H03f42keLjYEoRZzYtHPC5DuPE0UayiWGckI6BCDgy0sRKXCYS49UNFaQ==",
 			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/util-endpoints/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/util-endpoints/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/util-hex-encoding": {
-			"version": "3.201.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-			"integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+			"integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
 			"dependencies": {
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
+		},
+		"node_modules/@aws-sdk/util-hex-encoding/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/util-locate-window": {
-			"version": "3.208.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
-			"integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
+			"integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
 			"dependencies": {
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
+		},
+		"node_modules/@aws-sdk/util-locate-window/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/util-middleware": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
-			"integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.310.0.tgz",
+			"integrity": "sha512-FTSUKL/eRb9X6uEZClrTe27QFXUNNp7fxYrPndZwk1hlaOP5ix+MIHBcI7pIiiY/JPfOUmPyZOu+HetlFXjWog==",
 			"dependencies": {
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/@aws-sdk/util-middleware/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
 		"node_modules/@aws-sdk/util-retry": {
-			"version": "3.229.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
-			"integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.310.0.tgz",
+			"integrity": "sha512-FwWGhCBLfoivTMUHu1LIn4NjrN9JLJ/aX5aZmbcPIOhZVFJj638j0qDgZXyfvVqBuBZh7M8kGq0Oahy3dp69OA==",
 			"dependencies": {
-				"@aws-sdk/service-error-classification": "3.229.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/service-error-classification": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
+		"node_modules/@aws-sdk/util-retry/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
 		"node_modules/@aws-sdk/util-stream-browser": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.226.0.tgz",
-			"integrity": "sha512-ZvjlA1ySaLd0DqUWTKmL7LsxfPhroAONpzsinaHmw9aZVL40s2cADU9eWgBdHTuAOeFklL7NP0cc6UiTFHKe8g==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.310.0.tgz",
+			"integrity": "sha512-bysXZHwFwvbqOTCScCdCnoLk1K3GCo0HRIYEZuL7O7MHrQmfaYRXcaft/p22+GUv9VeFXS/eJJZ5r4u32az94w==",
 			"dependencies": {
-				"@aws-sdk/fetch-http-handler": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-base64": "3.208.0",
-				"@aws-sdk/util-hex-encoding": "3.201.0",
-				"@aws-sdk/util-utf8-browser": "3.188.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/fetch-http-handler": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-base64": "3.310.0",
+				"@aws-sdk/util-hex-encoding": "3.310.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"tslib": "^2.5.0"
 			}
 		},
-		"node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/fetch-http-handler": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
-			"integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
-			"dependencies": {
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/querystring-builder": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-base64": "3.208.0",
-				"tslib": "^2.3.1"
-			}
-		},
-		"node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/protocol-http": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-			"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/querystring-builder": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
-			"integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
-			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-uri-escape": "3.201.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/util-stream-browser/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/util-stream-node": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.226.0.tgz",
-			"integrity": "sha512-HADXiIgDGoXcCLSKuPnjCLENf0iC0lzqqnymZu9H2FoACZhJB7DvJ9LnP51Pvw9lfCu+yvLzbMqSPdbXtMbRWg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.310.0.tgz",
+			"integrity": "sha512-hueAXFK0GVvnfYFgqbF7587xZfMZff5jlIFZOHqx7XVU7bl7qrRUCnphHk8H6yZ7RoQbDPcfmHJgtEoAJg1T1Q==",
 			"dependencies": {
-				"@aws-sdk/node-http-handler": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-buffer-from": "3.208.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/node-http-handler": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-buffer-from": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/util-stream-node/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/util-uri-escape": {
-			"version": "3.201.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-			"integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+			"integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
 			"dependencies": {
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
+		},
+		"node_modules/@aws-sdk/util-uri-escape/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/util-user-agent-browser": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
-			"integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.310.0.tgz",
+			"integrity": "sha512-yU/4QnHHuQ5z3vsUqMQVfYLbZGYwpYblPiuZx4Zo9+x0PBkNjYMqctdDcrpoH9Z2xZiDN16AmQGK1tix117ZKw==",
 			"dependencies": {
-				"@aws-sdk/types": "3.226.0",
+				"@aws-sdk/types": "3.310.0",
 				"bowser": "^2.11.0",
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
 			}
 		},
-		"node_modules/@aws-sdk/util-user-agent-browser/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/util-user-agent-browser/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
-			"integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.310.0.tgz",
+			"integrity": "sha512-Ra3pEl+Gn2BpeE7KiDGpi4zj7WJXZA5GXnGo3mjbi9+Y3zrbuhJAbdZO3mO/o7xDgMC6ph4xCTbaSGzU6b6EDg==",
 			"dependencies": {
-				"@aws-sdk/node-config-provider": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/node-config-provider": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
@@ -2335,71 +1639,69 @@
 				}
 			}
 		},
-		"node_modules/@aws-sdk/util-user-agent-node/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+		"node_modules/@aws-sdk/util-user-agent-node/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/util-utf8": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
+			"integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
 			"dependencies": {
-				"tslib": "^2.3.1"
+				"@aws-sdk/util-buffer-from": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/util-utf8-browser": {
-			"version": "3.188.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
-			"integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+			"version": "3.259.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+			"integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
 			"dependencies": {
 				"tslib": "^2.3.1"
 			}
 		},
-		"node_modules/@aws-sdk/util-utf8-node": {
-			"version": "3.208.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
-			"integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
-			"dependencies": {
-				"@aws-sdk/util-buffer-from": "3.208.0",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/util-utf8/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/util-waiter": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.226.0.tgz",
-			"integrity": "sha512-qYQMRxnu5k8qQihJXoIWMkBOj0+XkHHj/drLdbRnwL6ni6NcG8++cs9M3DSjIcxmxgF/7SLpDjn1H3sC7cYo4g==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.310.0.tgz",
+			"integrity": "sha512-AV5j3guH/Y4REu+Qh3eXQU9igljHuU4XjX2sADAgf54C0kkhcCCkkiuzk3IsX089nyJCqIcj5idbjdvpnH88Vw==",
 			"dependencies": {
-				"@aws-sdk/abort-controller": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/abort-controller": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/util-waiter/node_modules/@aws-sdk/types": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-			"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-			"dependencies": {
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
+		"node_modules/@aws-sdk/util-waiter/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@aws-sdk/xml-builder": {
-			"version": "3.201.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.201.0.tgz",
-			"integrity": "sha512-brRdB1wwMgjWEnOQsv7zSUhIQuh7DEicrfslAqHop4S4FtSI3GQAShpQqgOpMTNFYcpaWKmE/Y1MJmNY7xLCnw==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.310.0.tgz",
+			"integrity": "sha512-TqELu4mOuSIKQCqj63fGVs86Yh+vBx5nHRpWKNUNhB2nPTpfbziTs5c1X358be3peVWA4wPxW7Nt53KIg1tnNw==",
 			"dependencies": {
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
+		},
+		"node_modules/@aws-sdk/xml-builder/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@codemirror/state": {
 			"version": "6.2.0",
@@ -2514,6 +1816,140 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/@smithy/fetch-http-handler": {
+			"version": "2.2.7",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.7.tgz",
+			"integrity": "sha512-iSDBjxuH9TgrtMYAr7j5evjvkvgwLY3y+9D547uep+JNkZ1ZT+BaeU20j6I/bO/i26ilCWFImrlXTPsfQtZdIQ==",
+			"dependencies": {
+				"@smithy/protocol-http": "^3.0.10",
+				"@smithy/querystring-builder": "^2.0.14",
+				"@smithy/types": "^2.6.0",
+				"@smithy/util-base64": "^2.0.1",
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@smithy/fetch-http-handler/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/is-array-buffer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
+			"integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/is-array-buffer/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/protocol-http": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.10.tgz",
+			"integrity": "sha512-6+tjNk7rXW7YTeGo9qwxXj/2BFpJTe37kTj3EnZCoX/nH+NP/WLA7O83fz8XhkGqsaAhLUPo/bB12vvd47nsmg==",
+			"dependencies": {
+				"@smithy/types": "^2.6.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/protocol-http/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/querystring-builder": {
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.14.tgz",
+			"integrity": "sha512-lQ4pm9vTv9nIhl5jt6uVMPludr6syE2FyJmHsIJJuOD7QPIJnrf9HhUGf1iHh9KJ4CUv21tpOU3X6s0rB6uJ0g==",
+			"dependencies": {
+				"@smithy/types": "^2.6.0",
+				"@smithy/util-uri-escape": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/querystring-builder/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/types": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.6.0.tgz",
+			"integrity": "sha512-PgqxJq2IcdMF9iAasxcqZqqoOXBHufEfmbEUdN1pmJrJltT42b0Sc8UiYSWWzKkciIp9/mZDpzYi4qYG1qqg6g==",
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/types/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/util-base64": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.1.tgz",
+			"integrity": "sha512-DlI6XFYDMsIVN+GH9JtcRp3j02JEVuWIn/QOZisVzpIAprdsxGveFed0bjbMRCqmIFe8uetn5rxzNrBtIGrPIQ==",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-base64/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/util-buffer-from": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
+			"integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-buffer-from/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/util-uri-escape": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
+			"integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-uri-escape/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@types/codemirror": {
 			"version": "0.0.108",
@@ -3684,9 +3120,9 @@
 			"peer": true
 		},
 		"node_modules/fast-xml-parser": {
-			"version": "4.0.11",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-			"integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+			"integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
 			"dependencies": {
 				"strnum": "^1.0.5"
 			},
@@ -4639,6 +4075,14 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
 		"node_modules/w3c-keyname": {
 			"version": "2.2.6",
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.6.tgz",
@@ -4710,12 +4154,12 @@
 	},
 	"dependencies": {
 		"@aws-crypto/crc32": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
-			"integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+			"integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
 			"requires": {
-				"@aws-crypto/util": "^2.0.0",
-				"@aws-sdk/types": "^3.1.0",
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
 				"tslib": "^1.11.1"
 			},
 			"dependencies": {
@@ -4727,12 +4171,12 @@
 			}
 		},
 		"@aws-crypto/crc32c": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-2.0.0.tgz",
-			"integrity": "sha512-vF0eMdMHx3O3MoOXUfBZry8Y4ZDtcuskjjKgJz8YfIDjLStxTZrYXk+kZqtl6A0uCmmiN/Eb/JbC/CndTV1MHg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-3.0.0.tgz",
+			"integrity": "sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==",
 			"requires": {
-				"@aws-crypto/util": "^2.0.0",
-				"@aws-sdk/types": "^3.1.0",
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
 				"tslib": "^1.11.1"
 			},
 			"dependencies": {
@@ -4744,9 +4188,9 @@
 			}
 		},
 		"@aws-crypto/ie11-detection": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
-			"integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+			"integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
 			"requires": {
 				"tslib": "^1.11.1"
 			},
@@ -4759,13 +4203,14 @@
 			}
 		},
 		"@aws-crypto/sha1-browser": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-2.0.0.tgz",
-			"integrity": "sha512-3fIVRjPFY8EG5HWXR+ZJZMdWNRpwbxGzJ9IH9q93FpbgCH8u8GHRi46mZXp3cYD7gealmyqpm3ThZwLKJjWJhA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-3.0.0.tgz",
+			"integrity": "sha512-NJth5c997GLHs6nOYTzFKTbYdMNA6/1XlKVgnZoaZcQ7z7UJlOgj2JdbHE8tiYLS3fzXNCguct77SPGat2raSw==",
 			"requires": {
-				"@aws-crypto/ie11-detection": "^2.0.0",
-				"@aws-crypto/supports-web-crypto": "^2.0.0",
-				"@aws-sdk/types": "^3.1.0",
+				"@aws-crypto/ie11-detection": "^3.0.0",
+				"@aws-crypto/supports-web-crypto": "^3.0.0",
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
 				"@aws-sdk/util-locate-window": "^3.0.0",
 				"@aws-sdk/util-utf8-browser": "^3.0.0",
 				"tslib": "^1.11.1"
@@ -4779,15 +4224,15 @@
 			}
 		},
 		"@aws-crypto/sha256-browser": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
-			"integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+			"integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
 			"requires": {
-				"@aws-crypto/ie11-detection": "^2.0.0",
-				"@aws-crypto/sha256-js": "^2.0.0",
-				"@aws-crypto/supports-web-crypto": "^2.0.0",
-				"@aws-crypto/util": "^2.0.0",
-				"@aws-sdk/types": "^3.1.0",
+				"@aws-crypto/ie11-detection": "^3.0.0",
+				"@aws-crypto/sha256-js": "^3.0.0",
+				"@aws-crypto/supports-web-crypto": "^3.0.0",
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
 				"@aws-sdk/util-locate-window": "^3.0.0",
 				"@aws-sdk/util-utf8-browser": "^3.0.0",
 				"tslib": "^1.11.1"
@@ -4801,12 +4246,12 @@
 			}
 		},
 		"@aws-crypto/sha256-js": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-			"integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+			"integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
 			"requires": {
-				"@aws-crypto/util": "^2.0.0",
-				"@aws-sdk/types": "^3.1.0",
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
 				"tslib": "^1.11.1"
 			},
 			"dependencies": {
@@ -4818,9 +4263,9 @@
 			}
 		},
 		"@aws-crypto/supports-web-crypto": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
-			"integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+			"integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
 			"requires": {
 				"tslib": "^1.11.1"
 			},
@@ -4833,11 +4278,11 @@
 			}
 		},
 		"@aws-crypto/util": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
-			"integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+			"integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
 			"requires": {
-				"@aws-sdk/types": "^3.110.0",
+				"@aws-sdk/types": "^3.222.0",
 				"@aws-sdk/util-utf8-browser": "^3.0.0",
 				"tslib": "^1.11.1"
 			},
@@ -4850,669 +4295,484 @@
 			}
 		},
 		"@aws-sdk/abort-controller": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
-			"integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.310.0.tgz",
+			"integrity": "sha512-v1zrRQxDLA1MdPim159Vx/CPHqsB4uybSxRi1CnfHO5ZjHryx3a5htW2gdGAykVCul40+yJXvfpufMrELVxH+g==",
 			"requires": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/chunked-blob-reader": {
-			"version": "3.188.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.188.0.tgz",
-			"integrity": "sha512-zkPRFZZPL3eH+kH86LDYYXImiClA1/sW60zYOjse9Pgka+eDJlvBN6hcYxwDEKjcwATYiSRR1aVQHcfCinlGXg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.310.0.tgz",
+			"integrity": "sha512-CrJS3exo4mWaLnWxfCH+w88Ou0IcAZSIkk4QbmxiHl/5Dq705OLoxf4385MVyExpqpeVJYOYQ2WaD8i/pQZ2fg==",
 			"requires": {
-				"tslib": "^2.3.1"
-			}
-		},
-		"@aws-sdk/chunked-blob-reader-native": {
-			"version": "3.208.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.208.0.tgz",
-			"integrity": "sha512-JeOZ95PW+fJ6bbuqPySYqLqHk1n4+4ueEEraJsiUrPBV0S1ZtyvOGHcnGztKUjr2PYNaiexmpWuvUve9K12HRA==",
-			"requires": {
-				"@aws-sdk/util-base64": "3.208.0",
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+				}
 			}
 		},
 		"@aws-sdk/client-s3": {
-			"version": "3.241.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.241.0.tgz",
-			"integrity": "sha512-GxkiX4f+FUW2Lr3PySc1wuYlfU8QV2nx6KlBY8L8yf2txtajEL0/hhfo5Pbo4Uw1ZZlTv4iPHUOiTrm2R9Rhyg==",
+			"version": "3.317.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.317.0.tgz",
+			"integrity": "sha512-Y7AZMO/ikKFARsGYv7LKNELTDqJHjEpDTGEBBWnFkVoTmlquBsa9r0tU2nofP3uxSIkySPkkQpR50Zm/Q6zWyw==",
 			"requires": {
-				"@aws-crypto/sha1-browser": "2.0.0",
-				"@aws-crypto/sha256-browser": "2.0.0",
-				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/client-sts": "3.241.0",
-				"@aws-sdk/config-resolver": "3.234.0",
-				"@aws-sdk/credential-provider-node": "3.241.0",
-				"@aws-sdk/eventstream-serde-browser": "3.226.0",
-				"@aws-sdk/eventstream-serde-config-resolver": "3.226.0",
-				"@aws-sdk/eventstream-serde-node": "3.226.0",
-				"@aws-sdk/fetch-http-handler": "3.226.0",
-				"@aws-sdk/hash-blob-browser": "3.226.0",
-				"@aws-sdk/hash-node": "3.226.0",
-				"@aws-sdk/hash-stream-node": "3.226.0",
-				"@aws-sdk/invalid-dependency": "3.226.0",
-				"@aws-sdk/md5-js": "3.226.0",
-				"@aws-sdk/middleware-bucket-endpoint": "3.226.0",
-				"@aws-sdk/middleware-content-length": "3.226.0",
-				"@aws-sdk/middleware-endpoint": "3.226.0",
-				"@aws-sdk/middleware-expect-continue": "3.226.0",
-				"@aws-sdk/middleware-flexible-checksums": "3.226.0",
-				"@aws-sdk/middleware-host-header": "3.226.0",
-				"@aws-sdk/middleware-location-constraint": "3.226.0",
-				"@aws-sdk/middleware-logger": "3.226.0",
-				"@aws-sdk/middleware-recursion-detection": "3.226.0",
-				"@aws-sdk/middleware-retry": "3.235.0",
-				"@aws-sdk/middleware-sdk-s3": "3.231.0",
-				"@aws-sdk/middleware-serde": "3.226.0",
-				"@aws-sdk/middleware-signing": "3.226.0",
-				"@aws-sdk/middleware-ssec": "3.226.0",
-				"@aws-sdk/middleware-stack": "3.226.0",
-				"@aws-sdk/middleware-user-agent": "3.226.0",
-				"@aws-sdk/node-config-provider": "3.226.0",
-				"@aws-sdk/node-http-handler": "3.226.0",
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/signature-v4-multi-region": "3.226.0",
-				"@aws-sdk/smithy-client": "3.234.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/url-parser": "3.226.0",
-				"@aws-sdk/util-base64": "3.208.0",
-				"@aws-sdk/util-body-length-browser": "3.188.0",
-				"@aws-sdk/util-body-length-node": "3.208.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.234.0",
-				"@aws-sdk/util-defaults-mode-node": "3.234.0",
-				"@aws-sdk/util-endpoints": "3.241.0",
-				"@aws-sdk/util-retry": "3.229.0",
-				"@aws-sdk/util-stream-browser": "3.226.0",
-				"@aws-sdk/util-stream-node": "3.226.0",
-				"@aws-sdk/util-user-agent-browser": "3.226.0",
-				"@aws-sdk/util-user-agent-node": "3.226.0",
-				"@aws-sdk/util-utf8-browser": "3.188.0",
-				"@aws-sdk/util-utf8-node": "3.208.0",
-				"@aws-sdk/util-waiter": "3.226.0",
-				"@aws-sdk/xml-builder": "3.201.0",
-				"fast-xml-parser": "4.0.11",
-				"tslib": "^2.3.1"
+				"@aws-crypto/sha1-browser": "3.0.0",
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/client-sts": "3.316.0",
+				"@aws-sdk/config-resolver": "3.310.0",
+				"@aws-sdk/credential-provider-node": "3.316.0",
+				"@aws-sdk/eventstream-serde-browser": "3.310.0",
+				"@aws-sdk/eventstream-serde-config-resolver": "3.310.0",
+				"@aws-sdk/eventstream-serde-node": "3.310.0",
+				"@aws-sdk/fetch-http-handler": "3.310.0",
+				"@aws-sdk/hash-blob-browser": "3.310.0",
+				"@aws-sdk/hash-node": "3.310.0",
+				"@aws-sdk/hash-stream-node": "3.310.0",
+				"@aws-sdk/invalid-dependency": "3.310.0",
+				"@aws-sdk/md5-js": "3.310.0",
+				"@aws-sdk/middleware-bucket-endpoint": "3.310.0",
+				"@aws-sdk/middleware-content-length": "3.310.0",
+				"@aws-sdk/middleware-endpoint": "3.310.0",
+				"@aws-sdk/middleware-expect-continue": "3.310.0",
+				"@aws-sdk/middleware-flexible-checksums": "3.310.0",
+				"@aws-sdk/middleware-host-header": "3.310.0",
+				"@aws-sdk/middleware-location-constraint": "3.310.0",
+				"@aws-sdk/middleware-logger": "3.310.0",
+				"@aws-sdk/middleware-recursion-detection": "3.310.0",
+				"@aws-sdk/middleware-retry": "3.310.0",
+				"@aws-sdk/middleware-sdk-s3": "3.310.0",
+				"@aws-sdk/middleware-serde": "3.310.0",
+				"@aws-sdk/middleware-signing": "3.310.0",
+				"@aws-sdk/middleware-ssec": "3.310.0",
+				"@aws-sdk/middleware-stack": "3.310.0",
+				"@aws-sdk/middleware-user-agent": "3.310.0",
+				"@aws-sdk/node-config-provider": "3.310.0",
+				"@aws-sdk/node-http-handler": "3.310.0",
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/signature-v4-multi-region": "3.310.0",
+				"@aws-sdk/smithy-client": "3.316.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/url-parser": "3.310.0",
+				"@aws-sdk/util-base64": "3.310.0",
+				"@aws-sdk/util-body-length-browser": "3.310.0",
+				"@aws-sdk/util-body-length-node": "3.310.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.316.0",
+				"@aws-sdk/util-defaults-mode-node": "3.316.0",
+				"@aws-sdk/util-endpoints": "3.310.0",
+				"@aws-sdk/util-retry": "3.310.0",
+				"@aws-sdk/util-stream-browser": "3.310.0",
+				"@aws-sdk/util-stream-node": "3.310.0",
+				"@aws-sdk/util-user-agent-browser": "3.310.0",
+				"@aws-sdk/util-user-agent-node": "3.310.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"@aws-sdk/util-waiter": "3.310.0",
+				"@aws-sdk/xml-builder": "3.310.0",
+				"fast-xml-parser": "4.1.2",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/fetch-http-handler": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
-					"integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
-					"requires": {
-						"@aws-sdk/protocol-http": "3.226.0",
-						"@aws-sdk/querystring-builder": "3.226.0",
-						"@aws-sdk/types": "3.226.0",
-						"@aws-sdk/util-base64": "3.208.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/protocol-http": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-					"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-					"requires": {
-						"@aws-sdk/types": "3.226.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/querystring-builder": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
-					"integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
-					"requires": {
-						"@aws-sdk/types": "3.226.0",
-						"@aws-sdk/util-uri-escape": "3.201.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/client-sso": {
-			"version": "3.241.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.241.0.tgz",
-			"integrity": "sha512-Jm4HR+RYAqKMEYZvvWaq0NYUKKonyInOeubObXH4BLXZpmUBSdYCSjjLdNJY3jkQoxbDVPVMIurVNh5zT5SMRw==",
+			"version": "3.316.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.316.0.tgz",
+			"integrity": "sha512-wGXfIhR0lJGB8QTT0fwSwwklHePHxd2GW3IQt3trXnEYe0frmJ7vYRnVL5CSRKsikLDmaU7ll3SdsshMzQzo3w==",
 			"requires": {
-				"@aws-crypto/sha256-browser": "2.0.0",
-				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/config-resolver": "3.234.0",
-				"@aws-sdk/fetch-http-handler": "3.226.0",
-				"@aws-sdk/hash-node": "3.226.0",
-				"@aws-sdk/invalid-dependency": "3.226.0",
-				"@aws-sdk/middleware-content-length": "3.226.0",
-				"@aws-sdk/middleware-endpoint": "3.226.0",
-				"@aws-sdk/middleware-host-header": "3.226.0",
-				"@aws-sdk/middleware-logger": "3.226.0",
-				"@aws-sdk/middleware-recursion-detection": "3.226.0",
-				"@aws-sdk/middleware-retry": "3.235.0",
-				"@aws-sdk/middleware-serde": "3.226.0",
-				"@aws-sdk/middleware-stack": "3.226.0",
-				"@aws-sdk/middleware-user-agent": "3.226.0",
-				"@aws-sdk/node-config-provider": "3.226.0",
-				"@aws-sdk/node-http-handler": "3.226.0",
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/smithy-client": "3.234.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/url-parser": "3.226.0",
-				"@aws-sdk/util-base64": "3.208.0",
-				"@aws-sdk/util-body-length-browser": "3.188.0",
-				"@aws-sdk/util-body-length-node": "3.208.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.234.0",
-				"@aws-sdk/util-defaults-mode-node": "3.234.0",
-				"@aws-sdk/util-endpoints": "3.241.0",
-				"@aws-sdk/util-retry": "3.229.0",
-				"@aws-sdk/util-user-agent-browser": "3.226.0",
-				"@aws-sdk/util-user-agent-node": "3.226.0",
-				"@aws-sdk/util-utf8-browser": "3.188.0",
-				"@aws-sdk/util-utf8-node": "3.208.0",
-				"tslib": "^2.3.1"
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/config-resolver": "3.310.0",
+				"@aws-sdk/fetch-http-handler": "3.310.0",
+				"@aws-sdk/hash-node": "3.310.0",
+				"@aws-sdk/invalid-dependency": "3.310.0",
+				"@aws-sdk/middleware-content-length": "3.310.0",
+				"@aws-sdk/middleware-endpoint": "3.310.0",
+				"@aws-sdk/middleware-host-header": "3.310.0",
+				"@aws-sdk/middleware-logger": "3.310.0",
+				"@aws-sdk/middleware-recursion-detection": "3.310.0",
+				"@aws-sdk/middleware-retry": "3.310.0",
+				"@aws-sdk/middleware-serde": "3.310.0",
+				"@aws-sdk/middleware-stack": "3.310.0",
+				"@aws-sdk/middleware-user-agent": "3.310.0",
+				"@aws-sdk/node-config-provider": "3.310.0",
+				"@aws-sdk/node-http-handler": "3.310.0",
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/smithy-client": "3.316.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/url-parser": "3.310.0",
+				"@aws-sdk/util-base64": "3.310.0",
+				"@aws-sdk/util-body-length-browser": "3.310.0",
+				"@aws-sdk/util-body-length-node": "3.310.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.316.0",
+				"@aws-sdk/util-defaults-mode-node": "3.316.0",
+				"@aws-sdk/util-endpoints": "3.310.0",
+				"@aws-sdk/util-retry": "3.310.0",
+				"@aws-sdk/util-user-agent-browser": "3.310.0",
+				"@aws-sdk/util-user-agent-node": "3.310.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/fetch-http-handler": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
-					"integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
-					"requires": {
-						"@aws-sdk/protocol-http": "3.226.0",
-						"@aws-sdk/querystring-builder": "3.226.0",
-						"@aws-sdk/types": "3.226.0",
-						"@aws-sdk/util-base64": "3.208.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/protocol-http": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-					"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-					"requires": {
-						"@aws-sdk/types": "3.226.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/querystring-builder": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
-					"integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
-					"requires": {
-						"@aws-sdk/types": "3.226.0",
-						"@aws-sdk/util-uri-escape": "3.201.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/client-sso-oidc": {
-			"version": "3.241.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.241.0.tgz",
-			"integrity": "sha512-/Ml2QBGpGfUEeBrPzBZhSTBkHuXFD2EAZEIHGCBH4tKaURDI6/FoGI8P1Rl4BzoFt+II/Cr91Eox6YT9EwChsQ==",
+			"version": "3.316.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.316.0.tgz",
+			"integrity": "sha512-e2fvC7o42YV+LcZYfXCcvBn4L7NM9oNccnZ7T+pS6SFpHZlaqkw4uuQMRE6iUAof+Id7Mt7xDrz1x2yGlP+8GA==",
 			"requires": {
-				"@aws-crypto/sha256-browser": "2.0.0",
-				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/config-resolver": "3.234.0",
-				"@aws-sdk/fetch-http-handler": "3.226.0",
-				"@aws-sdk/hash-node": "3.226.0",
-				"@aws-sdk/invalid-dependency": "3.226.0",
-				"@aws-sdk/middleware-content-length": "3.226.0",
-				"@aws-sdk/middleware-endpoint": "3.226.0",
-				"@aws-sdk/middleware-host-header": "3.226.0",
-				"@aws-sdk/middleware-logger": "3.226.0",
-				"@aws-sdk/middleware-recursion-detection": "3.226.0",
-				"@aws-sdk/middleware-retry": "3.235.0",
-				"@aws-sdk/middleware-serde": "3.226.0",
-				"@aws-sdk/middleware-stack": "3.226.0",
-				"@aws-sdk/middleware-user-agent": "3.226.0",
-				"@aws-sdk/node-config-provider": "3.226.0",
-				"@aws-sdk/node-http-handler": "3.226.0",
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/smithy-client": "3.234.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/url-parser": "3.226.0",
-				"@aws-sdk/util-base64": "3.208.0",
-				"@aws-sdk/util-body-length-browser": "3.188.0",
-				"@aws-sdk/util-body-length-node": "3.208.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.234.0",
-				"@aws-sdk/util-defaults-mode-node": "3.234.0",
-				"@aws-sdk/util-endpoints": "3.241.0",
-				"@aws-sdk/util-retry": "3.229.0",
-				"@aws-sdk/util-user-agent-browser": "3.226.0",
-				"@aws-sdk/util-user-agent-node": "3.226.0",
-				"@aws-sdk/util-utf8-browser": "3.188.0",
-				"@aws-sdk/util-utf8-node": "3.208.0",
-				"tslib": "^2.3.1"
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/config-resolver": "3.310.0",
+				"@aws-sdk/fetch-http-handler": "3.310.0",
+				"@aws-sdk/hash-node": "3.310.0",
+				"@aws-sdk/invalid-dependency": "3.310.0",
+				"@aws-sdk/middleware-content-length": "3.310.0",
+				"@aws-sdk/middleware-endpoint": "3.310.0",
+				"@aws-sdk/middleware-host-header": "3.310.0",
+				"@aws-sdk/middleware-logger": "3.310.0",
+				"@aws-sdk/middleware-recursion-detection": "3.310.0",
+				"@aws-sdk/middleware-retry": "3.310.0",
+				"@aws-sdk/middleware-serde": "3.310.0",
+				"@aws-sdk/middleware-stack": "3.310.0",
+				"@aws-sdk/middleware-user-agent": "3.310.0",
+				"@aws-sdk/node-config-provider": "3.310.0",
+				"@aws-sdk/node-http-handler": "3.310.0",
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/smithy-client": "3.316.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/url-parser": "3.310.0",
+				"@aws-sdk/util-base64": "3.310.0",
+				"@aws-sdk/util-body-length-browser": "3.310.0",
+				"@aws-sdk/util-body-length-node": "3.310.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.316.0",
+				"@aws-sdk/util-defaults-mode-node": "3.316.0",
+				"@aws-sdk/util-endpoints": "3.310.0",
+				"@aws-sdk/util-retry": "3.310.0",
+				"@aws-sdk/util-user-agent-browser": "3.310.0",
+				"@aws-sdk/util-user-agent-node": "3.310.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/fetch-http-handler": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
-					"integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
-					"requires": {
-						"@aws-sdk/protocol-http": "3.226.0",
-						"@aws-sdk/querystring-builder": "3.226.0",
-						"@aws-sdk/types": "3.226.0",
-						"@aws-sdk/util-base64": "3.208.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/protocol-http": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-					"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-					"requires": {
-						"@aws-sdk/types": "3.226.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/querystring-builder": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
-					"integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
-					"requires": {
-						"@aws-sdk/types": "3.226.0",
-						"@aws-sdk/util-uri-escape": "3.201.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/client-sts": {
-			"version": "3.241.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.241.0.tgz",
-			"integrity": "sha512-vmlG8cJzRf8skCtTJbA2wBvD2c3NQ5gZryzJvTKDS06KzBzcEpnjlLseuTekcnOiRNekbFUX5hRu5Zj3N2ReLg==",
+			"version": "3.316.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.316.0.tgz",
+			"integrity": "sha512-5SD59+DRVy1mKckGs/5J8OwWpRS3E5v4BX19XaX/s9JJ5Rw9aZd9DP4SZVpeNXztIPjkQSEzHgrUVlZFB1QJgg==",
 			"requires": {
-				"@aws-crypto/sha256-browser": "2.0.0",
-				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/config-resolver": "3.234.0",
-				"@aws-sdk/credential-provider-node": "3.241.0",
-				"@aws-sdk/fetch-http-handler": "3.226.0",
-				"@aws-sdk/hash-node": "3.226.0",
-				"@aws-sdk/invalid-dependency": "3.226.0",
-				"@aws-sdk/middleware-content-length": "3.226.0",
-				"@aws-sdk/middleware-endpoint": "3.226.0",
-				"@aws-sdk/middleware-host-header": "3.226.0",
-				"@aws-sdk/middleware-logger": "3.226.0",
-				"@aws-sdk/middleware-recursion-detection": "3.226.0",
-				"@aws-sdk/middleware-retry": "3.235.0",
-				"@aws-sdk/middleware-sdk-sts": "3.226.0",
-				"@aws-sdk/middleware-serde": "3.226.0",
-				"@aws-sdk/middleware-signing": "3.226.0",
-				"@aws-sdk/middleware-stack": "3.226.0",
-				"@aws-sdk/middleware-user-agent": "3.226.0",
-				"@aws-sdk/node-config-provider": "3.226.0",
-				"@aws-sdk/node-http-handler": "3.226.0",
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/smithy-client": "3.234.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/url-parser": "3.226.0",
-				"@aws-sdk/util-base64": "3.208.0",
-				"@aws-sdk/util-body-length-browser": "3.188.0",
-				"@aws-sdk/util-body-length-node": "3.208.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.234.0",
-				"@aws-sdk/util-defaults-mode-node": "3.234.0",
-				"@aws-sdk/util-endpoints": "3.241.0",
-				"@aws-sdk/util-retry": "3.229.0",
-				"@aws-sdk/util-user-agent-browser": "3.226.0",
-				"@aws-sdk/util-user-agent-node": "3.226.0",
-				"@aws-sdk/util-utf8-browser": "3.188.0",
-				"@aws-sdk/util-utf8-node": "3.208.0",
-				"fast-xml-parser": "4.0.11",
-				"tslib": "^2.3.1"
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/config-resolver": "3.310.0",
+				"@aws-sdk/credential-provider-node": "3.316.0",
+				"@aws-sdk/fetch-http-handler": "3.310.0",
+				"@aws-sdk/hash-node": "3.310.0",
+				"@aws-sdk/invalid-dependency": "3.310.0",
+				"@aws-sdk/middleware-content-length": "3.310.0",
+				"@aws-sdk/middleware-endpoint": "3.310.0",
+				"@aws-sdk/middleware-host-header": "3.310.0",
+				"@aws-sdk/middleware-logger": "3.310.0",
+				"@aws-sdk/middleware-recursion-detection": "3.310.0",
+				"@aws-sdk/middleware-retry": "3.310.0",
+				"@aws-sdk/middleware-sdk-sts": "3.310.0",
+				"@aws-sdk/middleware-serde": "3.310.0",
+				"@aws-sdk/middleware-signing": "3.310.0",
+				"@aws-sdk/middleware-stack": "3.310.0",
+				"@aws-sdk/middleware-user-agent": "3.310.0",
+				"@aws-sdk/node-config-provider": "3.310.0",
+				"@aws-sdk/node-http-handler": "3.310.0",
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/smithy-client": "3.316.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/url-parser": "3.310.0",
+				"@aws-sdk/util-base64": "3.310.0",
+				"@aws-sdk/util-body-length-browser": "3.310.0",
+				"@aws-sdk/util-body-length-node": "3.310.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.316.0",
+				"@aws-sdk/util-defaults-mode-node": "3.316.0",
+				"@aws-sdk/util-endpoints": "3.310.0",
+				"@aws-sdk/util-retry": "3.310.0",
+				"@aws-sdk/util-user-agent-browser": "3.310.0",
+				"@aws-sdk/util-user-agent-node": "3.310.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"fast-xml-parser": "4.1.2",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/fetch-http-handler": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
-					"integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
-					"requires": {
-						"@aws-sdk/protocol-http": "3.226.0",
-						"@aws-sdk/querystring-builder": "3.226.0",
-						"@aws-sdk/types": "3.226.0",
-						"@aws-sdk/util-base64": "3.208.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/protocol-http": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-					"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-					"requires": {
-						"@aws-sdk/types": "3.226.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/querystring-builder": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
-					"integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
-					"requires": {
-						"@aws-sdk/types": "3.226.0",
-						"@aws-sdk/util-uri-escape": "3.201.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/config-resolver": {
-			"version": "3.234.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
-			"integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.310.0.tgz",
+			"integrity": "sha512-8vsT+/50lOqfDxka9m/rRt6oxv1WuGZoP8oPMk0Dt+TxXMbAzf4+rejBgiB96wshI1k3gLokYRjSQZn+dDtT8g==",
 			"requires": {
-				"@aws-sdk/signature-v4": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-config-provider": "3.208.0",
-				"@aws-sdk/util-middleware": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-config-provider": "3.310.0",
+				"@aws-sdk/util-middleware": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/credential-provider-env": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
-			"integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.310.0.tgz",
+			"integrity": "sha512-vvIPQpI16fj95xwS7M3D48F7QhZJBnnCgB5lR+b7So+vsG9ibm1mZRVGzVpdxCvgyOhHFbvrby9aalNJmmIP1A==",
 			"requires": {
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/property-provider": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/credential-provider-imds": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
-			"integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.310.0.tgz",
+			"integrity": "sha512-baxK7Zp6dai5AGW01FIW27xS2KAaPUmKLIXv5SvFYsUgXXvNW55im4uG3b+2gA0F7V+hXvVBH08OEqmwW6we5w==",
 			"requires": {
-				"@aws-sdk/node-config-provider": "3.226.0",
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/url-parser": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/node-config-provider": "3.310.0",
+				"@aws-sdk/property-provider": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/url-parser": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/credential-provider-ini": {
-			"version": "3.241.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.241.0.tgz",
-			"integrity": "sha512-CI+mu6h74Kzmscw35TvNkc/wYHsHPGAwP7humSHoWw53H9mVw21Ggft/dT1iFQQZWQ8BNXkzuXlNo1IlqwMgOA==",
+			"version": "3.316.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.316.0.tgz",
+			"integrity": "sha512-ZADkpdEjFCAXyzEpYbCRENlZ/AQEwevWdPd2yshjNo7xvOcepv4pPIBpYd8h9LvRafSLGA7zlWDz84hkIt+HKA==",
 			"requires": {
-				"@aws-sdk/credential-provider-env": "3.226.0",
-				"@aws-sdk/credential-provider-imds": "3.226.0",
-				"@aws-sdk/credential-provider-process": "3.226.0",
-				"@aws-sdk/credential-provider-sso": "3.241.0",
-				"@aws-sdk/credential-provider-web-identity": "3.226.0",
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/shared-ini-file-loader": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/credential-provider-env": "3.310.0",
+				"@aws-sdk/credential-provider-imds": "3.310.0",
+				"@aws-sdk/credential-provider-process": "3.310.0",
+				"@aws-sdk/credential-provider-sso": "3.316.0",
+				"@aws-sdk/credential-provider-web-identity": "3.310.0",
+				"@aws-sdk/property-provider": "3.310.0",
+				"@aws-sdk/shared-ini-file-loader": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/credential-provider-node": {
-			"version": "3.241.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.241.0.tgz",
-			"integrity": "sha512-08zPQcD5o9brQmzEipWHeHgU85aQcEF8MWLfpeyjO6e1/l7ysQ35NsS+PYtv77nLpGCx/X+ZuW/KXWoRrbw77w==",
+			"version": "3.316.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.316.0.tgz",
+			"integrity": "sha512-oE1LTXP8XZp4bT8LhBeolMRiz0RwnmHDC2XpUmWO8LTmbDNrQO0mVzxEvXDLeKaN5BIFIJqNFlMgjWUMa9Kwcw==",
 			"requires": {
-				"@aws-sdk/credential-provider-env": "3.226.0",
-				"@aws-sdk/credential-provider-imds": "3.226.0",
-				"@aws-sdk/credential-provider-ini": "3.241.0",
-				"@aws-sdk/credential-provider-process": "3.226.0",
-				"@aws-sdk/credential-provider-sso": "3.241.0",
-				"@aws-sdk/credential-provider-web-identity": "3.226.0",
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/shared-ini-file-loader": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/credential-provider-env": "3.310.0",
+				"@aws-sdk/credential-provider-imds": "3.310.0",
+				"@aws-sdk/credential-provider-ini": "3.316.0",
+				"@aws-sdk/credential-provider-process": "3.310.0",
+				"@aws-sdk/credential-provider-sso": "3.316.0",
+				"@aws-sdk/credential-provider-web-identity": "3.310.0",
+				"@aws-sdk/property-provider": "3.310.0",
+				"@aws-sdk/shared-ini-file-loader": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/credential-provider-process": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
-			"integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.310.0.tgz",
+			"integrity": "sha512-h73sg6GPMUWC+3zMCbA1nZ2O03nNJt7G96JdmnantiXBwHpRKWW8nBTLzx5uhXn6hTuTaoQRP/P+oxQJKYdMmA==",
 			"requires": {
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/shared-ini-file-loader": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/property-provider": "3.310.0",
+				"@aws-sdk/shared-ini-file-loader": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/credential-provider-sso": {
-			"version": "3.241.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.241.0.tgz",
-			"integrity": "sha512-6Bjd6eEIrVomRTrPrM4dlxusQm+KMJ9hLYKECCpFkwDKIK+pTgZNLRtQdalHyzwneHJPdimrm8cOv1kUQ8hPoA==",
+			"version": "3.316.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.316.0.tgz",
+			"integrity": "sha512-8/O2twlsoV1bDkZ9jd7JCMWsftfyoTyRT1UYscsKZGUDEgZRAxRkzS3GLYuLXEWNuxb1OB9rYk/cEJoxwy7T9g==",
 			"requires": {
-				"@aws-sdk/client-sso": "3.241.0",
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/shared-ini-file-loader": "3.226.0",
-				"@aws-sdk/token-providers": "3.241.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/client-sso": "3.316.0",
+				"@aws-sdk/property-provider": "3.310.0",
+				"@aws-sdk/shared-ini-file-loader": "3.310.0",
+				"@aws-sdk/token-providers": "3.316.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/credential-provider-web-identity": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
-			"integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.310.0.tgz",
+			"integrity": "sha512-H4SzuZXILNhK6/IR1uVvsUDZvzc051hem7GLyYghBCu8mU+tq28YhKE8MfSroi6eL2e5Vujloij1OM2EQQkPkw==",
 			"requires": {
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/property-provider": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/eventstream-codec": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.226.0.tgz",
-			"integrity": "sha512-6uPtR8vSwz3fqoZk9hrb6qBYdp3PJ22+JxV5Wimdesvow4kJXSgDQXIxEkxbv6SxB9tNRB4uJHD84RetHEi15Q==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.310.0.tgz",
+			"integrity": "sha512-clIeSgWbZbxwtsxZ/yoedNM0/kJFSIjjHPikuDGhxhqc+vP6TN3oYyVMFrYwFaTFhk2+S5wZcWYMw8Op1pWo+A==",
 			"requires": {
-				"@aws-crypto/crc32": "2.0.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-hex-encoding": "3.201.0",
-				"tslib": "^2.3.1"
+				"@aws-crypto/crc32": "3.0.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-hex-encoding": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/eventstream-serde-browser": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.226.0.tgz",
-			"integrity": "sha512-otYC5aZE9eJUqAlKpy8w0rPDQ1eKGvZPtgxWXmFYSO2lDVGfI1nBBNmdZ4MdHqNuQ7ucsKMQYF8BFJ65K2tYPA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.310.0.tgz",
+			"integrity": "sha512-3S6ziuQVALgEyz0TANGtYDVeG8ArK4Y05mcgrs8qUTmsvlDIXX37cR/DvmVbNB76M4IrsZeSAIajL9644CywkA==",
 			"requires": {
-				"@aws-sdk/eventstream-serde-universal": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/eventstream-serde-universal": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/eventstream-serde-config-resolver": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.226.0.tgz",
-			"integrity": "sha512-A56Gypg+lyEfA5cna+EUH9XTrj0SvRG1gwNW7lrUzviN36SeA/LFTUIOEjxVML3Lowy+EPAcrSZ67h6aepoAig==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.310.0.tgz",
+			"integrity": "sha512-8s1Qdn9STj+sV75nUp9yt0W6fHS4BZ2jTm4Z/1Pcbvh2Gqs0WjH5n2StS+pDW5Y9J/HSGBl0ogmUr5lC5bXFHg==",
 			"requires": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/eventstream-serde-node": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.226.0.tgz",
-			"integrity": "sha512-KWLnKkKDzI9RNkiK6OiSYpG/XjZfue6Bsp/vRG+H5z3fbXdHv4X2+iW+Efu2Kvn7jsUyUv82TCl57DyJ/HKYhQ==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.310.0.tgz",
+			"integrity": "sha512-kSnRomCgW43K9TmQYuwN9+AoYPnhyOKroanUMyZEzJk7rpCPMj4OzaUpXfDYOvznFNYn7NLaH6nHLJAr0VPlJA==",
 			"requires": {
-				"@aws-sdk/eventstream-serde-universal": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/eventstream-serde-universal": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/eventstream-serde-universal": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.226.0.tgz",
-			"integrity": "sha512-Q8viYM1Sv90/yIUqyWNeG1GEvyVlAI3GIrInQcCMC+xT59jS+IKGy2y7ojCvSWXnhf5/HMXKcmG092QsqeKy0Q==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.310.0.tgz",
+			"integrity": "sha512-Qyjt5k/waV5cDukpgT824ISZAz5U0pwzLz5ztR409u85AGNkF/9n7MS+LSyBUBSb0WJ5pUeSD47WBk+nLq9Nhw==",
 			"requires": {
-				"@aws-sdk/eventstream-codec": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/eventstream-codec": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
@@ -5528,32 +4788,6 @@
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/is-array-buffer": {
-					"version": "3.310.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-					"integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-					"requires": {
-						"tslib": "^2.5.0"
-					}
-				},
-				"@aws-sdk/util-base64": {
-					"version": "3.310.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-					"integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-					"requires": {
-						"@aws-sdk/util-buffer-from": "3.310.0",
-						"tslib": "^2.5.0"
-					}
-				},
-				"@aws-sdk/util-buffer-from": {
-					"version": "3.310.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-					"integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-					"requires": {
-						"@aws-sdk/is-array-buffer": "3.310.0",
-						"tslib": "^2.5.0"
-					}
-				},
 				"tslib": {
 					"version": "2.5.0",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
@@ -5562,649 +4796,455 @@
 			}
 		},
 		"@aws-sdk/hash-blob-browser": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.226.0.tgz",
-			"integrity": "sha512-5DCvWE6L4xGoViEHyjcPFuUe1G2EtNx8TqswWaoaKgyasP/yuRm4H99Ra7rqIrjCcSTAGD9NVsUQvVVw1bGt9w==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.310.0.tgz",
+			"integrity": "sha512-OoR8p0cbypToysLT0v3o2oyjy6+DKrY7GNCAzHOHJK9xmqXCt+DsjKoPeiY7o1sWX2aN6Plmvubj/zWxMKEn/A==",
 			"requires": {
-				"@aws-sdk/chunked-blob-reader": "3.188.0",
-				"@aws-sdk/chunked-blob-reader-native": "3.208.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/chunked-blob-reader": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/hash-node": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
-			"integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.310.0.tgz",
+			"integrity": "sha512-NvE2fhRc8GRwCXBfDehxVAWCmVwVMILliAKVPAEr4yz2CkYs0tqU51S48x23dtna07H4qHtgpeNqVTthcIQOEQ==",
 			"requires": {
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-buffer-from": "3.208.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-buffer-from": "3.310.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/hash-stream-node": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.226.0.tgz",
-			"integrity": "sha512-cgNTGlF8SdHaQXtjEmuLXz2U8SLM2JDKtIVPku/lHTMsUsEn+fuv2C+h1f/hvd4aNw5t1zggym7sO1/h/rv56Q==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.310.0.tgz",
+			"integrity": "sha512-ZoXdybNgvMz1Hl6k/e32xVL3jmG5p2IEk5mTtLfFEuskTJ74Z+VMYKkkF1whyy7KQfH83H+TQGnsGtlRCchQKw==",
 			"requires": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/invalid-dependency": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
-			"integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.310.0.tgz",
+			"integrity": "sha512-1s5RG5rSPXoa/aZ/Kqr5U/7lqpx+Ry81GprQ2bxWqJvWQIJ0IRUwo5pk8XFxbKVr/2a+4lZT/c3OGoBOM1yRRA==",
 			"requires": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/is-array-buffer": {
-			"version": "3.201.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-			"integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+			"integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
 			"requires": {
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+				}
 			}
 		},
 		"@aws-sdk/md5-js": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.226.0.tgz",
-			"integrity": "sha512-ENigJRNudqyh6xsch166SZ4gggHd3XzZJ8gkCU4CWPne04HcR3BkWSO774IuWooCHt8zkaEHKecPurRz6qR+Vw==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.310.0.tgz",
+			"integrity": "sha512-x5sRBUrEfLWAS1EhwbbDQ7cXq6uvBxh3qR2XAsnGvFFceTeAadk7cVogWxlk3PC+OCeeym7c3/6Bv2HQ2f1YyQ==",
 			"requires": {
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-utf8-browser": "3.188.0",
-				"@aws-sdk/util-utf8-node": "3.208.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/middleware-bucket-endpoint": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.226.0.tgz",
-			"integrity": "sha512-A1Vq5W2X7jgTfjqcKPmjoHohF0poP+9fxwL97fQMvzcwmjhtoCV3bLEpo6CGYx0pKPiSlRJXZkRwRPj2hDHDmA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.310.0.tgz",
+			"integrity": "sha512-uJJfHI7v4AgbJZRLtyI8ap2QRWkBokGc3iyUoQ+dVNT3/CE2ZCu694A6W+H0dRqg79dIE+f9CRNdtLGa/Ehhvg==",
 			"requires": {
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-arn-parser": "3.208.0",
-				"@aws-sdk/util-config-provider": "3.208.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-arn-parser": "3.310.0",
+				"@aws-sdk/util-config-provider": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/protocol-http": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-					"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-					"requires": {
-						"@aws-sdk/types": "3.226.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/middleware-content-length": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
-			"integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.310.0.tgz",
+			"integrity": "sha512-P8tQZxgDt6CAh1wd/W6WPzjc+uWPJwQkm+F7rAwRlM+k9q17HrhnksGDKcpuuLyIhPQYdmOMIkpKVgXGa4avhQ==",
 			"requires": {
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/protocol-http": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-					"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-					"requires": {
-						"@aws-sdk/types": "3.226.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/middleware-endpoint": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
-			"integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.310.0.tgz",
+			"integrity": "sha512-Z+N2vOL8K354/lstkClxLLsr6hCpVRh+0tCMXrVj66/NtKysCEZ/0b9LmqOwD9pWHNiI2mJqXwY0gxNlKAroUg==",
 			"requires": {
-				"@aws-sdk/middleware-serde": "3.226.0",
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/signature-v4": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/url-parser": "3.226.0",
-				"@aws-sdk/util-config-provider": "3.208.0",
-				"@aws-sdk/util-middleware": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/middleware-serde": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/url-parser": "3.310.0",
+				"@aws-sdk/util-middleware": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/protocol-http": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-					"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-					"requires": {
-						"@aws-sdk/types": "3.226.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/middleware-expect-continue": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.226.0.tgz",
-			"integrity": "sha512-YxvQKTV/eA9P8AgW0hXOgj5Qa+TSnNFfyOkfeP089aP3f6p92b1cESf33TEOKsddive2mHT5LRCN6MuPcgWWrA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.310.0.tgz",
+			"integrity": "sha512-l3d1z2gt+gINJDnPSyu84IxfzjzPfCQrqC1sunw2cZGo/sXtEiq698Q3SiTcO2PGP4LBQAy2RHb5wVBJP708CQ==",
 			"requires": {
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/protocol-http": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-					"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-					"requires": {
-						"@aws-sdk/types": "3.226.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/middleware-flexible-checksums": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.226.0.tgz",
-			"integrity": "sha512-8A9Ot9A7794UP5tMGl2MnfTW/UM/jYy1wRWF9YkR/hPIcPb7OmE0hmlwIQGzb/7grxpYw66ETKf0WeH/41YfeQ==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.310.0.tgz",
+			"integrity": "sha512-5ndnLgzgGVpWkmHBAiYkagHqiSuow8q62J4J6E2PzaQ77+fm8W3nfdy7hK5trHokEyouCZdxT/XK/IRhgj/4PA==",
 			"requires": {
-				"@aws-crypto/crc32": "2.0.0",
-				"@aws-crypto/crc32c": "2.0.0",
-				"@aws-sdk/is-array-buffer": "3.201.0",
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-crypto/crc32": "3.0.0",
+				"@aws-crypto/crc32c": "3.0.0",
+				"@aws-sdk/is-array-buffer": "3.310.0",
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/protocol-http": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-					"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-					"requires": {
-						"@aws-sdk/types": "3.226.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/middleware-host-header": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
-			"integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.310.0.tgz",
+			"integrity": "sha512-QWSA+46/hXorXyWa61ic2K7qZzwHTiwfk2e9mRRjeIRepUgI3qxFjsYqrWtrOGBjmFmq0pYIY8Bb/DCJuQqcoA==",
 			"requires": {
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/protocol-http": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-					"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-					"requires": {
-						"@aws-sdk/types": "3.226.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/middleware-location-constraint": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.226.0.tgz",
-			"integrity": "sha512-qHiYaBYPc2R37KxG2uqsUUwh4usrQMHfGkrpTUnx5d4rGzM3mC+muPsTpSHnAL63K2/yJOHQJFjss3GGwV4SSA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.310.0.tgz",
+			"integrity": "sha512-LFm0JTQWwTPWL/tZU2wsQTl8J5PpDEkXjEhaXVKamtyH0xhysRqd+0n92n65dc8oztAuQkb9xUbErGn5b6gsew==",
 			"requires": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/middleware-logger": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
-			"integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.310.0.tgz",
+			"integrity": "sha512-Lurm8XofrASBRnAVtiSNuDSRsRqPNg27RIFLLsLp/pqog9nFJ0vz0kgdb9S5Z+zw83Mm+UlqOe6D8NTUNp4fVg==",
 			"requires": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/middleware-recursion-detection": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
-			"integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.310.0.tgz",
+			"integrity": "sha512-SuB75/xk/gyue24gkriTwO2jFd7YcUGZDClQYuRejgbXSa3CO0lWyawQtfLcSSEBp9izrEVXuFH24K1eAft5nQ==",
 			"requires": {
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/protocol-http": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-					"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-					"requires": {
-						"@aws-sdk/types": "3.226.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/middleware-retry": {
-			"version": "3.235.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
-			"integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.310.0.tgz",
+			"integrity": "sha512-oTPsRy2W4s+dfxbJPW7Km+hHtv/OMsNsVfThAq8DDYKC13qlr1aAyOqGLD+dpBy2aKe7ss517Sy2HcHtHqm7/g==",
 			"requires": {
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/service-error-classification": "3.229.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-middleware": "3.226.0",
-				"@aws-sdk/util-retry": "3.229.0",
-				"tslib": "^2.3.1",
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/service-error-classification": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-middleware": "3.310.0",
+				"@aws-sdk/util-retry": "3.310.0",
+				"tslib": "^2.5.0",
 				"uuid": "^8.3.2"
 			},
 			"dependencies": {
-				"@aws-sdk/protocol-http": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-					"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-					"requires": {
-						"@aws-sdk/types": "3.226.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
-				},
-				"uuid": {
-					"version": "8.3.2",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/middleware-sdk-s3": {
-			"version": "3.231.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.231.0.tgz",
-			"integrity": "sha512-UGaSvevd2TanfKgStF46dDSHkh4bxOr1gdUkyHm9i+1pF5lx4KdbnBZv/5SKnn7XifhHRXrs1M3lTzemXREhTA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.310.0.tgz",
+			"integrity": "sha512-QK9x9g2ksg0hOjjYgqddeFcn5ctUEGdxJVu4OumPXceulefMcSO2jyH2qTybYSA93nqNQFdFmg5wQfvIRUWFCQ==",
 			"requires": {
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-arn-parser": "3.208.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-arn-parser": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/protocol-http": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-					"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-					"requires": {
-						"@aws-sdk/types": "3.226.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/middleware-sdk-sts": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
-			"integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.310.0.tgz",
+			"integrity": "sha512-+5PFwlYNLvLLIfw0ASAoWV/iIF8Zv6R6QGtyP0CclhRSvNjgbQDVnV0g95MC5qvh+GB/Yjlkt8qAjLSPjHfsrQ==",
 			"requires": {
-				"@aws-sdk/middleware-signing": "3.226.0",
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/signature-v4": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/middleware-signing": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/protocol-http": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-					"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-					"requires": {
-						"@aws-sdk/types": "3.226.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/middleware-serde": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
-			"integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.310.0.tgz",
+			"integrity": "sha512-RNeeTVWSLTaentUeCgQKZhAl+C6hxtwD78cQWS10UymWpQFwbaxztzKUu4UQS5xA2j6PxwPRRUjqa4jcFjfLsg==",
 			"requires": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/middleware-signing": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
-			"integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.310.0.tgz",
+			"integrity": "sha512-f9mKq+XMdW207Af3hKjdTnpNhdtwqWuvFs/ZyXoOkp/g1MY1O6L23Jy6i52m29LxbT4AuNRG1oKODfXM0vYVjQ==",
 			"requires": {
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/signature-v4": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-middleware": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/property-provider": "3.310.0",
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/signature-v4": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-middleware": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/protocol-http": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-					"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-					"requires": {
-						"@aws-sdk/types": "3.226.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/middleware-ssec": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.226.0.tgz",
-			"integrity": "sha512-DR97oWoLHiMdaUP/wu99HtzG7/ijvCrjZGDH37WBO1rxFtEti6L7T09wgHzwxMN8gtL8FJA7dU8IrffGSC9VmA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.310.0.tgz",
+			"integrity": "sha512-CnEwNKVpd5bXnrCKPaePF8mWTA9ET21OMBb54y9b0fd8K02zoOcdBz4DWfh1SjFD4HkgCdja4egd8l2ivyvqmw==",
 			"requires": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/middleware-stack": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
-			"integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.310.0.tgz",
+			"integrity": "sha512-010O1PD+UAcZVKRvqEusE1KJqN96wwrf6QsqbRM0ywsKQ21NDweaHvEDlds2VHpgmofxkRLRu/IDrlPkKRQrRg==",
 			"requires": {
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+				}
 			}
 		},
 		"@aws-sdk/middleware-user-agent": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
-			"integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.310.0.tgz",
+			"integrity": "sha512-x3IOwSwSbwKidlxRk3CNVHVUb06SRuaELxggCaR++QVI8NU6qD/l4VHXKVRvbTHiC/cYxXE/GaBDgQVpDR7V/g==",
 			"requires": {
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-endpoints": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/protocol-http": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-					"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-					"requires": {
-						"@aws-sdk/types": "3.226.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/node-config-provider": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
-			"integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.310.0.tgz",
+			"integrity": "sha512-T/Pp6htc6hq/Cq+MLNDSyiwWCMVF6GqbBbXKVlO5L8rdHx4sq9xPdoPveZhGWrxvkanjA6eCwUp6E0riBOSVng==",
 			"requires": {
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/shared-ini-file-loader": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/property-provider": "3.310.0",
+				"@aws-sdk/shared-ini-file-loader": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/node-http-handler": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
-			"integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.310.0.tgz",
+			"integrity": "sha512-irv9mbcM9xC2xYjArQF5SYmHBMu4ciMWtGsoHII1nRuFOl9FoT4ffTvEPuLlfC6pznzvKt9zvnm6xXj7gDChKg==",
 			"requires": {
-				"@aws-sdk/abort-controller": "3.226.0",
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/querystring-builder": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/abort-controller": "3.310.0",
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/querystring-builder": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/protocol-http": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-					"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-					"requires": {
-						"@aws-sdk/types": "3.226.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/querystring-builder": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
-					"integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
-					"requires": {
-						"@aws-sdk/types": "3.226.0",
-						"@aws-sdk/util-uri-escape": "3.201.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/property-provider": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
-			"integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.310.0.tgz",
+			"integrity": "sha512-3lxDb0akV6BBzmFe4nLPaoliQbAifyWJhuvuDOu7e8NzouvpQXs0275w9LePhhcgjKAEVXUIse05ZW2DLbxo/g==",
 			"requires": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
@@ -6234,14 +5274,6 @@
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/util-uri-escape": {
-					"version": "3.310.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-					"integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
-					"requires": {
-						"tslib": "^2.5.0"
-					}
-				},
 				"tslib": {
 					"version": "2.5.0",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
@@ -6250,141 +5282,114 @@
 			}
 		},
 		"@aws-sdk/querystring-parser": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
-			"integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.310.0.tgz",
+			"integrity": "sha512-YkIznoP6lsiIUHinx++/lbb3tlMURGGqMpo0Pnn32zYzGrJXA6eC3D0as2EcMjo55onTfuLcIiX4qzXes2MYOA==",
 			"requires": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/service-error-classification": {
-			"version": "3.229.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
-			"integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg=="
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.310.0.tgz",
+			"integrity": "sha512-PuyC7k3qfIKeH2LCnDwbttMOKq3qAx4buvg0yfnJtQOz6t1AR8gsnAq0CjKXXyfkXwNKWTqCpE6lVNUIkXgsMw=="
 		},
 		"@aws-sdk/shared-ini-file-loader": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
-			"integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.310.0.tgz",
+			"integrity": "sha512-N0q9pG0xSjQwc690YQND5bofm+4nfUviQ/Ppgan2kU6aU0WUq8KwgHJBto/YEEI+VlrME30jZJnxtOvcZJc2XA==",
 			"requires": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/signature-v4": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
-			"integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.310.0.tgz",
+			"integrity": "sha512-1M60P1ZBNAjCFv9sYW29OF6okktaeibWyW3lMXqzoHF70lHBZh+838iUchznXUA5FLabfn4jBFWMRxlAXJUY2Q==",
 			"requires": {
-				"@aws-sdk/is-array-buffer": "3.201.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-hex-encoding": "3.201.0",
-				"@aws-sdk/util-middleware": "3.226.0",
-				"@aws-sdk/util-uri-escape": "3.201.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/is-array-buffer": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-hex-encoding": "3.310.0",
+				"@aws-sdk/util-middleware": "3.310.0",
+				"@aws-sdk/util-uri-escape": "3.310.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/signature-v4-multi-region": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.226.0.tgz",
-			"integrity": "sha512-QHxNuf9ynK208v7Y3imdsa3Cz8ynYV7ZOf3sBJdItuEtHN6uy/KxaOrtvpF8I5Hyn48Hc8z5miTSMujFKT7GEw==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.310.0.tgz",
+			"integrity": "sha512-q8W+RIomTS/q85Ntgks/CoDElwqkC9+4OCicee5YznNHjQ4gtNWhUkYIyIRWRmXa/qx/AUreW9DM8FAecCOdng==",
 			"requires": {
-				"@aws-sdk/protocol-http": "3.226.0",
-				"@aws-sdk/signature-v4": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-arn-parser": "3.208.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/protocol-http": "3.310.0",
+				"@aws-sdk/signature-v4": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/protocol-http": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-					"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-					"requires": {
-						"@aws-sdk/types": "3.226.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/smithy-client": {
-			"version": "3.234.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
-			"integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
+			"version": "3.316.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.316.0.tgz",
+			"integrity": "sha512-6YXOKbRnXeS8r8RWzuL6JMBolDYM5Wa4fD/VY6x/wK78i2xErHOvqzHgyyeLI1MMw4uqyd4wRNJNWC9TMPduXw==",
 			"requires": {
-				"@aws-sdk/middleware-stack": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/middleware-stack": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/token-providers": {
-			"version": "3.241.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.241.0.tgz",
-			"integrity": "sha512-79okvuOS7V559OIL/RalIPG98wzmWxeFOChFnbEjn2pKOyGQ6FJRwLPYZaVRtNdAtnkBNgRpmFq9dX843QxhtQ==",
+			"version": "3.316.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.316.0.tgz",
+			"integrity": "sha512-foJ2YmB8A/mtp52riO2zdmBgzA3IpASNgUhY9FZg1BKpGcjqLQDGYP+BY3BA0H7CFsMa4PCf13M5wWwn1onyBA==",
 			"requires": {
-				"@aws-sdk/client-sso-oidc": "3.241.0",
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/shared-ini-file-loader": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/client-sso-oidc": "3.316.0",
+				"@aws-sdk/property-provider": "3.310.0",
+				"@aws-sdk/shared-ini-file-loader": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
@@ -6404,337 +5409,370 @@
 			}
 		},
 		"@aws-sdk/url-parser": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
-			"integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.310.0.tgz",
+			"integrity": "sha512-mCLnCaSB9rQvAgx33u0DujLvr4d5yEm/W5r789GblwwQnlNXedVu50QRizMLTpltYWyAUoXjJgQnJHmJMaKXhw==",
 			"requires": {
-				"@aws-sdk/querystring-parser": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/querystring-parser": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/util-arn-parser": {
-			"version": "3.208.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.208.0.tgz",
-			"integrity": "sha512-QV4af+kscova9dv4VuHOgH8wEr/IIYHDGcnyVtkUEqahCejWr1Kuk+SBK0xMwnZY5LSycOtQ8aeqHOn9qOjZtA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.310.0.tgz",
+			"integrity": "sha512-jL8509owp/xB9+Or0pvn3Fe+b94qfklc2yPowZZIFAkFcCSIdkIglz18cPDWnYAcy9JGewpMS1COXKIUhZkJsA==",
 			"requires": {
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+				}
 			}
 		},
 		"@aws-sdk/util-base64": {
-			"version": "3.208.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
-			"integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+			"integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
 			"requires": {
-				"@aws-sdk/util-buffer-from": "3.208.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/util-buffer-from": "3.310.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+				}
 			}
 		},
 		"@aws-sdk/util-body-length-browser": {
-			"version": "3.188.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-			"integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+			"integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
 			"requires": {
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+				}
 			}
 		},
 		"@aws-sdk/util-body-length-node": {
-			"version": "3.208.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
-			"integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+			"integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
 			"requires": {
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+				}
 			}
 		},
 		"@aws-sdk/util-buffer-from": {
-			"version": "3.208.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-			"integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+			"integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
 			"requires": {
-				"@aws-sdk/is-array-buffer": "3.201.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/is-array-buffer": "3.310.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+				}
 			}
 		},
 		"@aws-sdk/util-config-provider": {
-			"version": "3.208.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-			"integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+			"integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
 			"requires": {
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+				}
 			}
 		},
 		"@aws-sdk/util-defaults-mode-browser": {
-			"version": "3.234.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
-			"integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
+			"version": "3.316.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.316.0.tgz",
+			"integrity": "sha512-6FSqLhYmaihtH2n1s4b2rlLW0ABU8N6VZIfzLfe2ING4PF0MzfaMMhnTFUHVXfKCVGoR8yP6iyFTRCyHGVEL1w==",
 			"requires": {
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
+				"@aws-sdk/property-provider": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
 				"bowser": "^2.11.0",
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/util-defaults-mode-node": {
-			"version": "3.234.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
-			"integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
+			"version": "3.316.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.316.0.tgz",
+			"integrity": "sha512-dkYy10hdjPSScXXvnjGpZpnJxllkb6ICHgLMwZ4JczLHhPM12T/4PQ758YN8HS+muiYDGX1Bl2z1jd/bMcewBQ==",
 			"requires": {
-				"@aws-sdk/config-resolver": "3.234.0",
-				"@aws-sdk/credential-provider-imds": "3.226.0",
-				"@aws-sdk/node-config-provider": "3.226.0",
-				"@aws-sdk/property-provider": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/config-resolver": "3.310.0",
+				"@aws-sdk/credential-provider-imds": "3.310.0",
+				"@aws-sdk/node-config-provider": "3.310.0",
+				"@aws-sdk/property-provider": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/util-endpoints": {
-			"version": "3.241.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.241.0.tgz",
-			"integrity": "sha512-jVf8bKrN22Ey0xLmj75sL7EUvm5HFpuOMkXsZkuXycKhCwLBcEUWlvtJYtRjOU1zScPQv9GMJd2QXQglp34iOQ==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.310.0.tgz",
+			"integrity": "sha512-zG+/d/O5KPmAaeOMPd6bW1abifdT0H03f42keLjYEoRZzYtHPC5DuPE0UayiWGckI6BCDgy0sRKXCYS49UNFaQ==",
 			"requires": {
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/util-hex-encoding": {
-			"version": "3.201.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-			"integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+			"integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
 			"requires": {
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+				}
 			}
 		},
 		"@aws-sdk/util-locate-window": {
-			"version": "3.208.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
-			"integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
+			"integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
 			"requires": {
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+				}
 			}
 		},
 		"@aws-sdk/util-middleware": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
-			"integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.310.0.tgz",
+			"integrity": "sha512-FTSUKL/eRb9X6uEZClrTe27QFXUNNp7fxYrPndZwk1hlaOP5ix+MIHBcI7pIiiY/JPfOUmPyZOu+HetlFXjWog==",
 			"requires": {
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+				}
 			}
 		},
 		"@aws-sdk/util-retry": {
-			"version": "3.229.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
-			"integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.310.0.tgz",
+			"integrity": "sha512-FwWGhCBLfoivTMUHu1LIn4NjrN9JLJ/aX5aZmbcPIOhZVFJj638j0qDgZXyfvVqBuBZh7M8kGq0Oahy3dp69OA==",
 			"requires": {
-				"@aws-sdk/service-error-classification": "3.229.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/service-error-classification": "3.310.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+				}
 			}
 		},
 		"@aws-sdk/util-stream-browser": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.226.0.tgz",
-			"integrity": "sha512-ZvjlA1ySaLd0DqUWTKmL7LsxfPhroAONpzsinaHmw9aZVL40s2cADU9eWgBdHTuAOeFklL7NP0cc6UiTFHKe8g==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.310.0.tgz",
+			"integrity": "sha512-bysXZHwFwvbqOTCScCdCnoLk1K3GCo0HRIYEZuL7O7MHrQmfaYRXcaft/p22+GUv9VeFXS/eJJZ5r4u32az94w==",
 			"requires": {
-				"@aws-sdk/fetch-http-handler": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-base64": "3.208.0",
-				"@aws-sdk/util-hex-encoding": "3.201.0",
-				"@aws-sdk/util-utf8-browser": "3.188.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/fetch-http-handler": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-base64": "3.310.0",
+				"@aws-sdk/util-hex-encoding": "3.310.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/fetch-http-handler": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
-					"integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
-					"requires": {
-						"@aws-sdk/protocol-http": "3.226.0",
-						"@aws-sdk/querystring-builder": "3.226.0",
-						"@aws-sdk/types": "3.226.0",
-						"@aws-sdk/util-base64": "3.208.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/protocol-http": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-					"integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-					"requires": {
-						"@aws-sdk/types": "3.226.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/querystring-builder": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
-					"integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
-					"requires": {
-						"@aws-sdk/types": "3.226.0",
-						"@aws-sdk/util-uri-escape": "3.201.0",
-						"tslib": "^2.3.1"
-					}
-				},
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/util-stream-node": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.226.0.tgz",
-			"integrity": "sha512-HADXiIgDGoXcCLSKuPnjCLENf0iC0lzqqnymZu9H2FoACZhJB7DvJ9LnP51Pvw9lfCu+yvLzbMqSPdbXtMbRWg==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.310.0.tgz",
+			"integrity": "sha512-hueAXFK0GVvnfYFgqbF7587xZfMZff5jlIFZOHqx7XVU7bl7qrRUCnphHk8H6yZ7RoQbDPcfmHJgtEoAJg1T1Q==",
 			"requires": {
-				"@aws-sdk/node-http-handler": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"@aws-sdk/util-buffer-from": "3.208.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/node-http-handler": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"@aws-sdk/util-buffer-from": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/util-uri-escape": {
-			"version": "3.201.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-			"integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+			"integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
 			"requires": {
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+				}
 			}
 		},
 		"@aws-sdk/util-user-agent-browser": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
-			"integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.310.0.tgz",
+			"integrity": "sha512-yU/4QnHHuQ5z3vsUqMQVfYLbZGYwpYblPiuZx4Zo9+x0PBkNjYMqctdDcrpoH9Z2xZiDN16AmQGK1tix117ZKw==",
 			"requires": {
-				"@aws-sdk/types": "3.226.0",
+				"@aws-sdk/types": "3.310.0",
 				"bowser": "^2.11.0",
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/util-user-agent-node": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
-			"integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.310.0.tgz",
+			"integrity": "sha512-Ra3pEl+Gn2BpeE7KiDGpi4zj7WJXZA5GXnGo3mjbi9+Y3zrbuhJAbdZO3mO/o7xDgMC6ph4xCTbaSGzU6b6EDg==",
 			"requires": {
-				"@aws-sdk/node-config-provider": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/node-config-provider": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+				}
+			}
+		},
+		"@aws-sdk/util-utf8": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
+			"integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
+			"requires": {
+				"@aws-sdk/util-buffer-from": "3.310.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/util-utf8-browser": {
-			"version": "3.188.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
-			"integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+			"version": "3.259.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+			"integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
 			"requires": {
-				"tslib": "^2.3.1"
-			}
-		},
-		"@aws-sdk/util-utf8-node": {
-			"version": "3.208.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
-			"integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
-			"requires": {
-				"@aws-sdk/util-buffer-from": "3.208.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/util-waiter": {
-			"version": "3.226.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.226.0.tgz",
-			"integrity": "sha512-qYQMRxnu5k8qQihJXoIWMkBOj0+XkHHj/drLdbRnwL6ni6NcG8++cs9M3DSjIcxmxgF/7SLpDjn1H3sC7cYo4g==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.310.0.tgz",
+			"integrity": "sha512-AV5j3guH/Y4REu+Qh3eXQU9igljHuU4XjX2sADAgf54C0kkhcCCkkiuzk3IsX089nyJCqIcj5idbjdvpnH88Vw==",
 			"requires": {
-				"@aws-sdk/abort-controller": "3.226.0",
-				"@aws-sdk/types": "3.226.0",
-				"tslib": "^2.3.1"
+				"@aws-sdk/abort-controller": "3.310.0",
+				"@aws-sdk/types": "3.310.0",
+				"tslib": "^2.5.0"
 			},
 			"dependencies": {
-				"@aws-sdk/types": {
-					"version": "3.226.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-					"integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
-					"requires": {
-						"tslib": "^2.3.1"
-					}
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 				}
 			}
 		},
 		"@aws-sdk/xml-builder": {
-			"version": "3.201.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.201.0.tgz",
-			"integrity": "sha512-brRdB1wwMgjWEnOQsv7zSUhIQuh7DEicrfslAqHop4S4FtSI3GQAShpQqgOpMTNFYcpaWKmE/Y1MJmNY7xLCnw==",
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.310.0.tgz",
+			"integrity": "sha512-TqELu4mOuSIKQCqj63fGVs86Yh+vBx5nHRpWKNUNhB2nPTpfbziTs5c1X358be3peVWA4wPxW7Nt53KIg1tnNw==",
 			"requires": {
-				"tslib": "^2.3.1"
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+				}
 			}
 		},
 		"@codemirror/state": {
@@ -6824,6 +5862,135 @@
 			"requires": {
 				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
+			}
+		},
+		"@smithy/fetch-http-handler": {
+			"version": "2.2.7",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.7.tgz",
+			"integrity": "sha512-iSDBjxuH9TgrtMYAr7j5evjvkvgwLY3y+9D547uep+JNkZ1ZT+BaeU20j6I/bO/i26ilCWFImrlXTPsfQtZdIQ==",
+			"requires": {
+				"@smithy/protocol-http": "^3.0.10",
+				"@smithy/querystring-builder": "^2.0.14",
+				"@smithy/types": "^2.6.0",
+				"@smithy/util-base64": "^2.0.1",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+				}
+			}
+		},
+		"@smithy/is-array-buffer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
+			"integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+			"requires": {
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+				}
+			}
+		},
+		"@smithy/protocol-http": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.10.tgz",
+			"integrity": "sha512-6+tjNk7rXW7YTeGo9qwxXj/2BFpJTe37kTj3EnZCoX/nH+NP/WLA7O83fz8XhkGqsaAhLUPo/bB12vvd47nsmg==",
+			"requires": {
+				"@smithy/types": "^2.6.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+				}
+			}
+		},
+		"@smithy/querystring-builder": {
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.14.tgz",
+			"integrity": "sha512-lQ4pm9vTv9nIhl5jt6uVMPludr6syE2FyJmHsIJJuOD7QPIJnrf9HhUGf1iHh9KJ4CUv21tpOU3X6s0rB6uJ0g==",
+			"requires": {
+				"@smithy/types": "^2.6.0",
+				"@smithy/util-uri-escape": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+				}
+			}
+		},
+		"@smithy/types": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.6.0.tgz",
+			"integrity": "sha512-PgqxJq2IcdMF9iAasxcqZqqoOXBHufEfmbEUdN1pmJrJltT42b0Sc8UiYSWWzKkciIp9/mZDpzYi4qYG1qqg6g==",
+			"requires": {
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+				}
+			}
+		},
+		"@smithy/util-base64": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.1.tgz",
+			"integrity": "sha512-DlI6XFYDMsIVN+GH9JtcRp3j02JEVuWIn/QOZisVzpIAprdsxGveFed0bjbMRCqmIFe8uetn5rxzNrBtIGrPIQ==",
+			"requires": {
+				"@smithy/util-buffer-from": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+				}
+			}
+		},
+		"@smithy/util-buffer-from": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
+			"integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+			"requires": {
+				"@smithy/is-array-buffer": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+				}
+			}
+		},
+		"@smithy/util-uri-escape": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
+			"integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+			"requires": {
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+				}
 			}
 		},
 		"@types/codemirror": {
@@ -7582,9 +6749,9 @@
 			"peer": true
 		},
 		"fast-xml-parser": {
-			"version": "4.0.11",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-			"integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+			"integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
 			"requires": {
 				"strnum": "^1.0.5"
 			}
@@ -8268,6 +7435,11 @@
 			"requires": {
 				"punycode": "^2.1.0"
 			}
+		},
+		"uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
 		},
 		"w3c-keyname": {
 			"version": "2.2.6",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,11 @@
 		"typescript": "4.7.4"
 	},
 	"dependencies": {
-		"@aws-sdk/client-s3": "^3.241.0",
+		"@aws-sdk/client-s3": "3.317.0",
 		"@aws-sdk/fetch-http-handler": "^3.310.0",
 		"@aws-sdk/protocol-http": "^3.310.0",
 		"@aws-sdk/querystring-builder": "^3.310.0",
-		"@aws-sdk/types": "^3.310.0"
+		"@aws-sdk/types": "^3.310.0",
+		"@smithy/fetch-http-handler": "^2.2.7"
 	}
 }


### PR DESCRIPTION
Due to a change in the AWS API the plugin was failing to upload to S3.

This change switches to @smithy/fetch-http-handler and enables keepAlive on the HTTP connections to fix this issue.

Tested on Ubuntu 23.04 and Obsidian 1.4.16