### PR TITLE
fix # google cloud storage "SignatureDoesNotMatch"

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -308,6 +308,7 @@ export default class S3UploaderPlugin extends Plugin {
 			this.s3 = new S3Client({
 				region: this.settings.region,
 				credentials: {
+					clientConfig: {region: this.settings.region},
 					accessKeyId: this.settings.accessKey,
 					secretAccessKey: this.settings.secretKey,
 				},
@@ -319,6 +320,7 @@ export default class S3UploaderPlugin extends Plugin {
 			this.s3 = new S3Client({
 				region: this.settings.region,
 				credentials: {
+					clientConfig: {region: this.settings.region},
 					accessKeyId: this.settings.accessKey,
 					secretAccessKey: this.settings.secretKey,
 				},


### PR DESCRIPTION
fix # google cloud storage "SignatureDoesNotMatch" https://github.com/aws/aws-sdk-js-v3/issues/5052#issuecomment-1665990835