### PR TITLE
feat: Restore `localUploadFolder` functionality for per-file upload p…

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -158,7 +158,7 @@ export default class S3UploaderPlugin extends Plugin {
 				const placeholder = `![uploading...](${newFileName})\n`;
 				editor.replaceSelection(placeholder);
 
-				let folder = fm?.folder ?? this.settings.folder;
+				let folder = fm?.folder ?? this.settings.localUploadFolder;
 				const currentDate = new Date();
 				folder = folder
 					.replace("${year}", currentDate.getFullYear().toString())


### PR DESCRIPTION
Fixes issue #22 

Restore the ability to specify the upload path per note using `localUploadFolder` YAML frontmatter metadata.