### PR TITLE
Improved image compression experience

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -33,7 +33,7 @@ interface pasteFunction {
 	(
 		this: HTMLElement,
 		event: ClipboardEvent | DragEvent,
-		editor: Editor
+		editor: Editor,
 	): void;
 }
 
@@ -99,7 +99,7 @@ export default class S3UploaderPlugin extends Plugin {
 	private async replaceText(
 		editor: Editor,
 		target: string,
-		replacement: string
+		replacement: string,
 	): Promise<void> {
 		const content = editor.getValue();
 		const position = content.indexOf(target);
@@ -112,11 +112,11 @@ export default class S3UploaderPlugin extends Plugin {
 			// Check if we're in a table by looking for pipe characters around the target
 			const surroundingBefore = content.substring(
 				Math.max(0, position - 20),
-				position
+				position,
 			);
 			const surroundingAfter = content.substring(
 				position + target.length,
-				Math.min(content.length, position + target.length + 20)
+				Math.min(content.length, position + target.length + 20),
 			);
 
 			console.log("Surrounding text:", {
@@ -197,7 +197,7 @@ export default class S3UploaderPlugin extends Plugin {
 				Key: key,
 				Body: new Uint8Array(buf),
 				ContentType: file.type,
-			})
+			}),
 		);
 		let urlString = this.settings.imageUrlPath + key;
 		if (this.settings.queryStringKey && this.settings.queryStringValue) {
@@ -206,7 +206,7 @@ export default class S3UploaderPlugin extends Plugin {
 			// The searchParams property provides methods to manipulate query parameters
 			urlObject.searchParams.append(
 				this.settings.queryStringKey,
-				this.settings.queryStringValue
+				this.settings.queryStringValue,
 			);
 			urlString = urlObject.toString();
 		}
@@ -233,7 +233,7 @@ export default class S3UploaderPlugin extends Plugin {
 	async pasteHandler(
 		ev: ClipboardEvent | DragEvent | Event | null,
 		editor: Editor,
-		directFile?: File
+		directFile?: File,
 	): Promise<void> {
 		if (ev?.defaultPrevented) {
 			return;
@@ -255,7 +255,7 @@ export default class S3UploaderPlugin extends Plugin {
 			switch (ev.type) {
 				case "paste":
 					files = Array.from(
-						(ev as ClipboardEvent).clipboardData?.files || []
+						(ev as ClipboardEvent).clipboardData?.files || [],
 					);
 					break;
 				case "drop":
@@ -266,11 +266,13 @@ export default class S3UploaderPlugin extends Plugin {
 						return;
 					}
 					files = Array.from(
-						(ev as DragEvent).dataTransfer?.files || []
+						(ev as DragEvent).dataTransfer?.files || [],
 					);
 					break;
 				case "input":
-					files = Array.from((ev.target as HTMLInputElement).files || []);
+					files = Array.from(
+						(ev.target as HTMLInputElement).files || [],
+					);
 					break;
 			}
 		}
@@ -322,11 +324,11 @@ export default class S3UploaderPlugin extends Plugin {
 					.replace("${year}", currentDate.getFullYear().toString())
 					.replace(
 						"${month}",
-						String(currentDate.getMonth() + 1).padStart(2, "0")
+						String(currentDate.getMonth() + 1).padStart(2, "0"),
 					)
 					.replace(
 						"${day}",
-						String(currentDate.getDate()).padStart(2, "0")
+						String(currentDate.getDate()).padStart(2, "0"),
 					);
 				const key = folder ? `${folder}/${newFileName}` : newFileName;
 
@@ -335,19 +337,22 @@ export default class S3UploaderPlugin extends Plugin {
 					let url;
 
 					// Image compression
-					if (thisType === "image" && this.settings.enableImageCompression) {
+					if (
+						thisType === "image" &&
+						this.settings.enableImageCompression
+					) {
 						buf = await this.compressImage(file);
 						file = new File([buf], newFileName, {
 							type: file.type,
 						});
 					}
-					
+
 					if (!localUpload) {
 						url = await this.uploadFile(file, key);
 					} else {
 						await this.app.vault.adapter.writeBinary(
 							key,
-							new Uint8Array(buf)
+							new Uint8Array(buf),
 						);
 						url =
 							this.app.vault.adapter instanceof FileSystemAdapter
@@ -369,7 +374,7 @@ export default class S3UploaderPlugin extends Plugin {
 
 				// Filter out undefined results (from unsupported file types)
 				const validResults = results.filter(
-					(result) => result !== undefined
+					(result) => result !== undefined,
 				);
 
 				// Insert all results at once at the cursor position
@@ -456,16 +461,16 @@ export default class S3UploaderPlugin extends Plugin {
 
 		this.pasteFunction = (
 			event: ClipboardEvent | DragEvent,
-			editor: Editor
+			editor: Editor,
 		) => {
 			this.pasteHandler(event, editor);
 		};
 
 		this.registerEvent(
-			this.app.workspace.on("editor-paste", this.pasteFunction)
+			this.app.workspace.on("editor-paste", this.pasteFunction),
 		);
 		this.registerEvent(
-			this.app.workspace.on("editor-drop", this.pasteFunction)
+			this.app.workspace.on("editor-drop", this.pasteFunction),
 		);
 		// Add mobile-specific event monitoring
 		this.registerEvent(
@@ -497,7 +502,7 @@ export default class S3UploaderPlugin extends Plugin {
 					if (position !== -1) {
 						const from = activeView.editor.offsetToPos(position);
 						const to = activeView.editor.offsetToPos(
-							position + obsidianLink.length
+							position + obsidianLink.length,
 						);
 						activeView.editor.replaceRange("", from, to);
 					} else {
@@ -508,17 +513,17 @@ export default class S3UploaderPlugin extends Plugin {
 				} catch (error) {
 					new Notice(`Error processing file: ${error.message}`);
 				}
-			})
+			}),
 		);
 	}
 
-	onunload() { }
+	onunload() {}
 
 	async loadSettings() {
 		this.settings = Object.assign(
 			{},
 			DEFAULT_SETTINGS,
-			await this.loadData()
+			await this.loadData(),
 		);
 	}
 
@@ -544,11 +549,17 @@ class S3UploaderSettingTab extends PluginSettingTab {
 	 * @param show Whether to show the compression settings
 	 */
 	private toggleCompressionSettings(show: boolean): void {
-		if (this.compressionSizeSettings && this.compressionQualitySettings && this.compressionDimensionSettings) {
+		if (
+			this.compressionSizeSettings &&
+			this.compressionQualitySettings &&
+			this.compressionDimensionSettings
+		) {
 			const displayStyle = show ? "" : "none";
 			this.compressionSizeSettings.settingEl.style.display = displayStyle;
-			this.compressionQualitySettings.settingEl.style.display = displayStyle;
-			this.compressionDimensionSettings.settingEl.style.display = displayStyle;
+			this.compressionQualitySettings.settingEl.style.display =
+				displayStyle;
+			this.compressionDimensionSettings.settingEl.style.display =
+				displayStyle;
 		}
 	}
 
@@ -609,7 +620,7 @@ class S3UploaderSettingTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						this.plugin.settings.region = value.trim();
 						await this.plugin.saveSettings();
-					})
+					}),
 			);
 
 		new Setting(containerEl)
@@ -622,13 +633,13 @@ class S3UploaderSettingTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						this.plugin.settings.bucket = value.trim();
 						await this.plugin.saveSettings();
-					})
+					}),
 			);
 
 		new Setting(containerEl)
 			.setName("Bucket folder")
 			.setDesc(
-				"Optional folder in s3 bucket. Support the use of ${year}, ${month}, and ${day} variables."
+				"Optional folder in s3 bucket. Support the use of ${year}, ${month}, and ${day} variables.",
 			)
 			.addText((text) =>
 				text
@@ -637,13 +648,13 @@ class S3UploaderSettingTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						this.plugin.settings.folder = value.trim();
 						await this.plugin.saveSettings();
-					})
+					}),
 			);
 
 		new Setting(containerEl)
 			.setName("Upload on drag")
 			.setDesc(
-				"Upload drag and drop images as well as pasted images. To override this setting on a per-document basis, you can add `uploadOnDrag: true` to YAML frontmatter of the note."
+				"Upload drag and drop images as well as pasted images. To override this setting on a per-document basis, you can add `uploadOnDrag: true` to YAML frontmatter of the note.",
 			)
 			.addToggle((toggle) => {
 				toggle
@@ -657,7 +668,7 @@ class S3UploaderSettingTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("Upload video files")
 			.setDesc(
-				"Upload videos. To override this setting on a per-document basis, you can add `uploadVideo: true` to YAML frontmatter of the note."
+				"Upload videos. To override this setting on a per-document basis, you can add `uploadVideo: true` to YAML frontmatter of the note.",
 			)
 			.addToggle((toggle) => {
 				toggle
@@ -671,7 +682,7 @@ class S3UploaderSettingTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("Upload audio files")
 			.setDesc(
-				"Upload audio files. To override this setting on a per-document basis, you can add `uploadAudio: true` to YAML frontmatter of the note."
+				"Upload audio files. To override this setting on a per-document basis, you can add `uploadAudio: true` to YAML frontmatter of the note.",
 			)
 			.addToggle((toggle) => {
 				toggle
@@ -685,7 +696,7 @@ class S3UploaderSettingTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("Upload pdf files")
 			.setDesc(
-				"Upload and embed PDF files. To override this setting on a per-document basis, you can add `uploadPdf: true` to YAML frontmatter of the note. Local uploads are not supported for PDF files."
+				"Upload and embed PDF files. To override this setting on a per-document basis, you can add `uploadPdf: true` to YAML frontmatter of the note. Local uploads are not supported for PDF files.",
 			)
 			.addToggle((toggle) => {
 				toggle
@@ -699,7 +710,7 @@ class S3UploaderSettingTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("Copy to local folder")
 			.setDesc(
-				"Copy images to local folder instead of s3. To override this setting on a per-document basis, you can add `localUpload: true` to YAML frontmatter of the note.  This will copy the images to a folder in your local file system, instead of s3."
+				"Copy images to local folder instead of s3. To override this setting on a per-document basis, you can add `localUpload: true` to YAML frontmatter of the note.  This will copy the images to a folder in your local file system, instead of s3.",
 			)
 			.addToggle((toggle) => {
 				toggle
@@ -713,7 +724,7 @@ class S3UploaderSettingTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("Local folder")
 			.setDesc(
-				'Local folder to save images, instead of s3. To override this setting on a per-document basis, you can add `uploadFolder: "myFolder"` to YAML frontmatter of the note.  This affects only local uploads.'
+				'Local folder to save images, instead of s3. To override this setting on a per-document basis, you can add `uploadFolder: "myFolder"` to YAML frontmatter of the note.  This affects only local uploads.',
 			)
 			.addText((text) =>
 				text
@@ -722,7 +733,7 @@ class S3UploaderSettingTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						this.plugin.settings.localUploadFolder = value.trim();
 						await this.plugin.saveSettings();
-					})
+					}),
 			);
 
 		new Setting(containerEl)
@@ -740,7 +751,7 @@ class S3UploaderSettingTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("Custom S3 Endpoint")
 			.setDesc(
-				"Optionally set a custom endpoint for any S3 compatible storage provider."
+				"Optionally set a custom endpoint for any S3 compatible storage provider.",
 			)
 			.addText((text) =>
 				text
@@ -753,13 +764,13 @@ class S3UploaderSettingTab extends PluginSettingTab {
 						value = value.replace(/([^/])$/, "$1/"); // Force to end with slash
 						this.plugin.settings.customEndpoint = value.trim();
 						await this.plugin.saveSettings();
-					})
+					}),
 			);
 
 		new Setting(containerEl)
 			.setName("S3 Path Style URLs")
 			.setDesc(
-				"Advanced option to force using (legacy) path-style s3 URLs (s3.myhost.com/bucket) instead of the modern AWS standard host-style (bucket.s3.myhost.com)."
+				"Advanced option to force using (legacy) path-style s3 URLs (s3.myhost.com/bucket) instead of the modern AWS standard host-style (bucket.s3.myhost.com).",
 			)
 			.addToggle((toggle) => {
 				toggle
@@ -785,7 +796,7 @@ class S3UploaderSettingTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("Custom Image URL")
 			.setDesc(
-				"Advanced option to force inserting custom image URLs. This option is helpful if you are using CDN."
+				"Advanced option to force inserting custom image URLs. This option is helpful if you are using CDN.",
 			)
 			.addText((text) =>
 				text
@@ -797,13 +808,13 @@ class S3UploaderSettingTab extends PluginSettingTab {
 						value = value.replace(/([^/])$/, "$1/"); // Force to end with slash
 						this.plugin.settings.customImageUrl = value.trim();
 						await this.plugin.saveSettings();
-					})
+					}),
 			);
 
 		new Setting(containerEl)
 			.setName("Bypass local CORS check")
 			.setDesc(
-				"Bypass local CORS preflight checks - it might work on later versions of Obsidian."
+				"Bypass local CORS preflight checks - it might work on later versions of Obsidian.",
 			)
 			.addToggle((toggle) => {
 				toggle
@@ -823,7 +834,7 @@ class S3UploaderSettingTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						this.plugin.settings.queryStringKey = value;
 						await this.plugin.saveSettings();
-					})
+					}),
 			);
 
 		new Setting(containerEl)
@@ -836,21 +847,19 @@ class S3UploaderSettingTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						this.plugin.settings.queryStringValue = value;
 						await this.plugin.saveSettings();
-					})
+					}),
 			);
 
 		new Setting(containerEl)
 			.setName("Enable Image Compression")
-			.setDesc(
-				"This will reduce the size of images before uploading."
-			)
+			.setDesc("This will reduce the size of images before uploading.")
 			.addToggle((toggle) => {
 				toggle
 					.setValue(this.plugin.settings.enableImageCompression)
 					.onChange(async (value) => {
 						this.plugin.settings.enableImageCompression = value;
 						await this.plugin.saveSettings();
-						
+
 						// Show or hide compression settings based on toggle value
 						this.toggleCompressionSettings(value);
 					});
@@ -858,40 +867,40 @@ class S3UploaderSettingTab extends PluginSettingTab {
 
 		// Always create the compression settings, but control visibility
 		this.compressionSizeSettings = new Setting(containerEl)
-			.setName("Max Image Compression Size")
+			.setName("Max Image Size")
 			.setDesc(
-				"Maximum size of the image after compression in MB. Default is 1MB."
+				"Maximum size of the image after compression in MB. Default is 1MB.",
 			)
 			.addText((text) =>
 				text
 					.setPlaceholder("1")
 					.setValue(
-						this.plugin.settings.maxImageCompressionSize.toString()
+						this.plugin.settings.maxImageCompressionSize.toString(),
 					)
 					.onChange(async (value) => {
 						// It must be a number, it must be greater than 0
-						const newValue = parseFloat(value)
+						const newValue = parseFloat(value);
 						if (isNaN(newValue) || newValue <= 0) {
 							new Notice(
-								"Max Image Compression Size must be a number greater than 0"
+								"Max Image Compression Size must be a number greater than 0",
 							);
 							return;
 						}
 
 						this.plugin.settings.maxImageCompressionSize = newValue;
 						await this.plugin.saveSettings();
-					})
+					}),
 			);
 
 		this.compressionQualitySettings = new Setting(containerEl)
-			.setName("Max Image Compression Quality")
+			.setName("Image Compression Quality")
 			.setDesc(
-				"Maximum quality of the image after compression. Default is 0.7."
+				"Maximum quality of the image after compression. Default is 0.7.",
 			)
 			.addSlider((slider) => {
 				slider.setDynamicTooltip();
 				slider.setLimits(0.0, 1.0, 0.05);
-				slider.setValue(this.plugin.settings.imageCompressionQuality)
+				slider.setValue(this.plugin.settings.imageCompressionQuality);
 				slider.onChange(async (value) => {
 					this.plugin.settings.imageCompressionQuality = value;
 					await this.plugin.saveSettings();
@@ -901,38 +910,41 @@ class S3UploaderSettingTab extends PluginSettingTab {
 		this.compressionDimensionSettings = new Setting(containerEl)
 			.setName("Max Image Width or Height")
 			.setDesc(
-				"Maximum width or height of the image after compression. Default is 4096px."
+				"Maximum width or height of the image after compression. Default is 4096px.",
 			)
 			.addText((text) =>
 				text
 					.setPlaceholder("4096")
 					.setValue(
-						this.plugin.settings.maxImageWidthOrHeight.toString()
+						this.plugin.settings.maxImageWidthOrHeight.toString(),
 					)
 					.onChange(async (value) => {
 						const parsedValue = parseInt(value);
 
 						if (isNaN(parsedValue) || parsedValue <= 0) {
 							new Notice(
-								"Max Image Width or Height must be a number greater than 0"
+								"Max Image Width or Height must be a number greater than 0",
 							);
 							return;
 						}
 
-						this.plugin.settings.maxImageWidthOrHeight = parsedValue;
+						this.plugin.settings.maxImageWidthOrHeight =
+							parsedValue;
 						await this.plugin.saveSettings();
-					})
+					}),
 			);
-			
+
 		// Set initial visibility based on current settings
-		this.toggleCompressionSettings(this.plugin.settings.enableImageCompression);
+		this.toggleCompressionSettings(
+			this.plugin.settings.enableImageCompression,
+		);
 	}
 }
 
 const wrapTextWithPasswordHide = (text: TextComponent) => {
 	const hider = text.inputEl.insertAdjacentElement(
 		"beforebegin",
-		createSpan()
+		createSpan(),
 	);
 	if (!hider) {
 		return;
@@ -957,7 +969,7 @@ const wrapTextWithPasswordHide = (text: TextComponent) => {
 const wrapFileDependingOnType = (
 	location: string,
 	type: string,
-	localBase: string
+	localBase: string,
 ) => {
 	const srcPrefix = localBase ? "file://" + localBase + "/" : "";
 
@@ -976,7 +988,7 @@ const wrapFileDependingOnType = (
 		</iframe>`;
 	} else if (type === "ppt") {
 		return `<iframe
-	    src='https://view.officeapps.live.com/op/embed.aspx?src=${location}' 
+	    src='https://view.officeapps.live.com/op/embed.aspx?src=${location}'
 	    width='100%' height='600px' frameborder='0'>
 	  </iframe>`;
 	} else {
@@ -1003,7 +1015,7 @@ class ObsHttpHandler extends FetchHttpHandler {
 	}
 	async handle(
 		request: HttpRequest,
-		{ abortSignal }: HttpHandlerOptions = {}
+		{ abortSignal }: HttpHandlerOptions = {},
 	): Promise<{ response: HttpResponse }> {
 		if (abortSignal?.aborted) {
 			const abortError = new Error("Request aborted");
@@ -1020,8 +1032,9 @@ class ObsHttpHandler extends FetchHttpHandler {
 		}
 
 		const { port, method } = request;
-		const url = `${request.protocol}//${request.hostname}${port ? `:${port}` : ""
-			}${path}`;
+		const url = `${request.protocol}//${request.hostname}${
+			port ? `:${port}` : ""
+		}${path}`;
 		const body =
 			method === "GET" || method === "HEAD" ? undefined : request.body;
 
@@ -1084,7 +1097,7 @@ class ObsHttpHandler extends FetchHttpHandler {
 						abortError.name = "AbortError";
 						reject(abortError);
 					};
-				})
+				}),
 			);
 		}
 		return Promise.race(raceOfPromises);

--- a/main.ts
+++ b/main.ts
@@ -217,8 +217,8 @@ export default class S3UploaderPlugin extends Plugin {
 		});
 
 		const fileBuffer = await compressedFile.arrayBuffer();
-		const originalSize = filesize(fileBuffer.byteLength);
-		const newSize = filesize(fileBuffer.byteLength);
+		const originalSize = filesize(file.size); // Input file size
+		const newSize = filesize(compressedFile.size);
 
 		new Notice(`Image compressed from ${originalSize} to ${newSize}`);
 

--- a/main.ts
+++ b/main.ts
@@ -211,9 +211,11 @@ export default class S3UploaderPlugin extends Plugin {
 	async compressImage(file: File): Promise<ArrayBuffer> {
 		const compressedFile = await imageCompression(file, {
 			useWebWorker: false,
-			maxWidthOrHeight: 1920,
-			// maxSizeMB: 1,
-			initialQuality: 0.8,
+			maxWidthOrHeight: 4096,
+			maxSizeMB: 1,
+			initialQuality: 0.7,
+			alwaysKeepResolution: false,
+			preserveExif: false,
 		});
 
 		const fileBuffer = await compressedFile.arrayBuffer();


### PR DESCRIPTION
This PR enhances the image compression, current configuration is very weak and not effective on lowering the size of large photos like camera taken images.

I believe setting the compression max size to `1MB` for best experience for S3 and image transmission.

Also fixes the compression message file size comparison, previous version shown (new size) -> (new size), we are supposed to show (old size) -> (new size)

Enhancements to image compression:

* [`main.ts`](diffhunk://#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0L214-R223): Increased `maxWidthOrHeight` from 1920 to 4096, set `maxSizeMB` to 1, adjusted `initialQuality` from 0.8 to 0.7, added `alwaysKeepResolution` set to false, and added `preserveExif` set to false.
* [`main.ts`](diffhunk://#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0L214-R223): Corrected the calculation of `originalSize` to use the input file size instead of the compressed file size.