### PR TITLE
add s3 client re-creation and support for filenames with spaces

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -504,7 +504,7 @@ export default class S3UploaderPlugin extends Plugin {
 					const obsidianLink = (this.app.vault as any).getConfig(
 						"useMarkdownLinks"
 					)
-						? `![](${file.name})`
+						? `![](${file.name.split(" ").join("%20")})`
 						: `![[${file.name}]]`; // Exact pattern we want to find
 					const position = content.indexOf(obsidianLink);
 

--- a/main.ts
+++ b/main.ts
@@ -401,12 +401,7 @@ export default class S3UploaderPlugin extends Plugin {
 		}
 	}
 
-	async onload() {
-		await this.loadSettings();
-
-		// This adds a settings tab so the user can configure various aspects of the plugin
-		this.addSettingTab(new S3UploaderSettingTab(this.app, this));
-
+	createS3Client(): void {
 		const apiEndpoint = this.settings.useCustomEndpoint
 			? this.settings.customEndpoint
 			: `https://s3.${this.settings.region}.amazonaws.com/`;
@@ -441,6 +436,15 @@ export default class S3UploaderPlugin extends Plugin {
 				requestHandler: new ObsHttpHandler({ keepAlive: false }),
 			});
 		}
+	}
+
+	async onload() {
+		await this.loadSettings();
+
+		// This adds a settings tab so the user can configure various aspects of the plugin
+		this.addSettingTab(new S3UploaderSettingTab(this.app, this));
+
+		this.createS3Client();
 
 		this.addCommand({
 			id: "upload-image",
@@ -598,6 +602,7 @@ class S3UploaderSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.accessKey)
 					.onChange(async (value) => {
 						this.plugin.settings.accessKey = value.trim();
+						this.plugin.createS3Client();
 						await this.plugin.saveSettings();
 					});
 			});
@@ -611,6 +616,7 @@ class S3UploaderSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.secretKey)
 					.onChange(async (value) => {
 						this.plugin.settings.secretKey = value.trim();
+						this.plugin.createS3Client();
 						await this.plugin.saveSettings();
 					});
 			});
@@ -624,6 +630,7 @@ class S3UploaderSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.region)
 					.onChange(async (value) => {
 						this.plugin.settings.region = value.trim();
+						this.plugin.createS3Client();
 						await this.plugin.saveSettings();
 					})
 			);
@@ -637,6 +644,7 @@ class S3UploaderSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.bucket)
 					.onChange(async (value) => {
 						this.plugin.settings.bucket = value.trim();
+						this.plugin.createS3Client();
 						await this.plugin.saveSettings();
 					})
 			);
@@ -749,6 +757,7 @@ class S3UploaderSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.useCustomEndpoint)
 					.onChange(async (value) => {
 						this.plugin.settings.useCustomEndpoint = value;
+						this.plugin.createS3Client();
 						await this.plugin.saveSettings();
 					});
 			});
@@ -768,6 +777,7 @@ class S3UploaderSettingTab extends PluginSettingTab {
 							: "https://" + value;
 						value = value.replace(/([^/])$/, "$1/"); // Force to end with slash
 						this.plugin.settings.customEndpoint = value.trim();
+						this.plugin.createS3Client();
 						await this.plugin.saveSettings();
 					})
 			);
@@ -782,6 +792,7 @@ class S3UploaderSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.forcePathStyle)
 					.onChange(async (value) => {
 						this.plugin.settings.forcePathStyle = value;
+						this.plugin.createS3Client();
 						await this.plugin.saveSettings();
 					});
 			});
@@ -794,6 +805,7 @@ class S3UploaderSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.useCustomImageUrl)
 					.onChange(async (value) => {
 						this.plugin.settings.useCustomImageUrl = value;
+						this.plugin.createS3Client();
 						await this.plugin.saveSettings();
 					});
 			});
@@ -812,6 +824,7 @@ class S3UploaderSettingTab extends PluginSettingTab {
 							: "https://" + value;
 						value = value.replace(/([^/])$/, "$1/"); // Force to end with slash
 						this.plugin.settings.customImageUrl = value.trim();
+						this.plugin.createS3Client();
 						await this.plugin.saveSettings();
 					})
 			);
@@ -826,6 +839,7 @@ class S3UploaderSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.bypassCors)
 					.onChange(async (value) => {
 						this.plugin.settings.bypassCors = value;
+						this.plugin.createS3Client();
 						await this.plugin.saveSettings();
 					});
 			});


### PR DESCRIPTION
- S3 Client Re-Creation:
  When the S3 related settings changed, S3Client object and `imageUrlPath` should be updated without reloading the plugin.
- Filenames with spaces:
  In markdown links mode, spaces are not allowed, and Obsidian automatically replaces them to "%20". So the matching pattern for original links also needs to be changed.

By the way, I found that when doing "bypassCors", [the code](https://github.com/jvsteiner/s3-image-uploader/blob/90a81d1f829a93e276c2863878bb4099490a9588/main.ts#L419-L443) in `if` and `else` is exactly the same. Is it preserved for any special use?