### PR TITLE
Optimised img compression with JPEG conversion

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -261,13 +261,17 @@ export default class S3UploaderPlugin extends Plugin {
 			fileType: fileType,
 		});
 
-		const fileBuffer = await compressedFile.arrayBuffer();
+		// Return original file if the compressed file size is larger than the original file size
+		if (compressedFile.size > file.size) {
+			return await file.arrayBuffer();
+		}
+
 		const originalSize = filesize(file.size); // Input file size
 		const newSize = filesize(compressedFile.size);
 
 		new Notice(`Image compressed from ${originalSize} to ${newSize}`);
 
-		return fileBuffer;
+		return await compressedFile.arrayBuffer();
 	}
 
 	async pasteHandler(

--- a/main.ts
+++ b/main.ts
@@ -254,7 +254,7 @@ export default class S3UploaderPlugin extends Plugin {
 
 	async compressImage(file: File, fileType: string): Promise<ArrayBuffer> {
 		const compressedFile = await imageCompression(file, {
-			useWebWorker: false,
+			useWebWorker: true,
 			maxWidthOrHeight: this.settings.maxImageWidthOrHeight,
 			maxSizeMB: this.settings.maxImageCompressionSize,
 			initialQuality: this.settings.imageCompressionQuality,

--- a/main.ts
+++ b/main.ts
@@ -614,7 +614,7 @@ export default class S3UploaderPlugin extends Plugin {
 		);
 	}
 
-	onunload() { }
+	onunload() {}
 
 	async loadSettings() {
 		this.settings = Object.assign(

--- a/main.ts
+++ b/main.ts
@@ -405,7 +405,7 @@ export default class S3UploaderPlugin extends Plugin {
 						const digest = await generateFileHash(new Uint8Array(buf));
 						newFileName = `${digest}.${file.name.split(".").pop()}`;
 
-						// Reserve transparency, only convert to JPEG if the file has no transparency
+						// Preserve transparency, only convert to JPEG if the file has no transparency
 						if (fileType.startsWith("image/png") && !(await this.hasPngAlpha(file))) {
 							fileType = "image/jpeg";
 

--- a/main.ts
+++ b/main.ts
@@ -1168,8 +1168,7 @@ class ObsHttpHandler extends FetchHttpHandler {
 		}
 
 		const { port, method } = request;
-		const url = `${request.protocol}//${request.hostname}${port ? `:${port}` : ""
-			}${path}`;
+		const url = `${request.protocol}//${request.hostname}${port ? `:${port}` : ""}${path}`;
 		const body =
 			method === "GET" || method === "HEAD" ? undefined : request.body;
 

--- a/main.ts
+++ b/main.ts
@@ -261,14 +261,16 @@ export default class S3UploaderPlugin extends Plugin {
 			fileType: fileType,
 		});
 
-		// Return original file if the compressed file size is larger than the original file size
-		if (compressedFile.size > file.size) {
-			return await file.arrayBuffer();
-		}
-
 		const originalSize = filesize(file.size); // Input file size
 		const newSize = filesize(compressedFile.size);
 
+		// Return original file if the compressed file size is larger than the original file size
+		if (compressedFile.size > file.size) {
+			new Notice(
+				`Image not compressed (original was smaller: ${originalSize} vs ${newSize})`,
+			);
+			return await file.arrayBuffer();
+		}
 		new Notice(`Image compressed from ${originalSize} to ${newSize}`);
 
 		return await compressedFile.arrayBuffer();

--- a/main.ts
+++ b/main.ts
@@ -238,18 +238,29 @@ export default class S3UploaderPlugin extends Plugin {
 	// Check if the PNG file has alpha channel
 	// In other words, if the file is a PNG with transparency
 	async hasPngAlpha(file: File): Promise<boolean> {
-		const [, canvas] = await imageCompression.drawFileInCanvas(file);
-		const ctx = canvas.getContext("2d");
+		try {
+			const [, canvas] = await imageCompression.drawFileInCanvas(file);
 
-		if (!ctx) return false;
+			// If we cannot obtain a valid canvas, conservatively assume the PNG has alpha
+			if (!canvas) {
+				return true;
+			}
 
-		const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height);
+			const ctx = canvas.getContext("2d");
 
-		for (let i = 3; i < data.length; i += 4) {
-			if (data[i] < 255) return true;
+			if (!ctx) return false;
+
+			const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height);
+
+			for (let i = 3; i < data.length; i += 4) {
+				if (data[i] < 255) return true;
+			}
+
+			return false;
+		} catch (e) {
+			// On any error, assume the PNG has alpha to preserve the original image format
+			return true;
 		}
-
-		return false;
 	}
 
 	async compressImage(file: File, fileType: string): Promise<ArrayBuffer> {

--- a/main.ts
+++ b/main.ts
@@ -357,8 +357,6 @@ export default class S3UploaderPlugin extends Plugin {
 
 				// Process the file
 				let buf = await file.arrayBuffer();
-				const digest = await generateFileHash(new Uint8Array(buf));
-				let newFileName = `${digest}.${file.name.split(".").pop()}`;
 
 				// Determine folder
 				let folder = "";
@@ -386,6 +384,9 @@ export default class S3UploaderPlugin extends Plugin {
 						noteFile.basename.replace(/ /g, "-"),
 					);
 
+
+				let newFileName = "";
+
 				try {
 					// Upload the file
 					let url;
@@ -398,6 +399,10 @@ export default class S3UploaderPlugin extends Plugin {
 						// Convert to JPEG from PNG if the file has no transparency
 						let fileType = file.type;
 
+						buf = await this.compressImage(file, fileType);
+						const digest = await generateFileHash(new Uint8Array(buf));
+						newFileName = `${digest}.${file.name.split(".").pop()}`;
+
 						// Reserve transparency, only convert to JPEG if the file has no transparency
 						if (fileType.startsWith("image/png") && !(await this.hasPngAlpha(file))) {
 							fileType = "image/jpeg";
@@ -406,10 +411,12 @@ export default class S3UploaderPlugin extends Plugin {
 							newFileName = `${digest}.jpeg`;
 						}
 
-						buf = await this.compressImage(file, fileType);
 						file = new File([buf], newFileName, {
 							type: fileType,
 						});
+					} else {
+						const digest = await generateFileHash(new Uint8Array(buf));
+						newFileName = `${digest}.${file.name.split(".").pop()}`;
 					}
 
 					const key = folder ? `${folder}/${newFileName}` : newFileName;

--- a/main.ts
+++ b/main.ts
@@ -235,12 +235,30 @@ export default class S3UploaderPlugin extends Plugin {
 		return urlString;
 	}
 
-	async compressImage(file: File): Promise<ArrayBuffer> {
+	// Check if the PNG file has alpha channel
+	// In other words, if the file is a PNG with transparency
+	async hasPngAlpha(file: File): Promise<boolean> {
+		const [, canvas] = await imageCompression.drawFileInCanvas(file);
+		const ctx = canvas.getContext("2d");
+
+		if (!ctx) return false;
+
+		const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height);
+
+		for (let i = 3; i < data.length; i += 4) {
+			if (data[i] < 255) return true;
+		}
+
+		return false;
+	}
+
+	async compressImage(file: File, fileType: string): Promise<ArrayBuffer> {
 		const compressedFile = await imageCompression(file, {
 			useWebWorker: false,
 			maxWidthOrHeight: this.settings.maxImageWidthOrHeight,
 			maxSizeMB: this.settings.maxImageCompressionSize,
 			initialQuality: this.settings.imageCompressionQuality,
+			fileType: fileType,
 		});
 
 		const fileBuffer = await compressedFile.arrayBuffer();
@@ -336,7 +354,7 @@ export default class S3UploaderPlugin extends Plugin {
 				// Process the file
 				let buf = await file.arrayBuffer();
 				const digest = await generateFileHash(new Uint8Array(buf));
-				const newFileName = `${digest}.${file.name.split(".").pop()}`;
+				let newFileName = `${digest}.${file.name.split(".").pop()}`;
 
 				// Determine folder
 				let folder = "";
@@ -364,8 +382,6 @@ export default class S3UploaderPlugin extends Plugin {
 						noteFile.basename.replace(/ /g, "-"),
 					);
 
-				const key = folder ? `${folder}/${newFileName}` : newFileName;
-
 				try {
 					// Upload the file
 					let url;
@@ -375,11 +391,24 @@ export default class S3UploaderPlugin extends Plugin {
 						thisType === "image" &&
 						this.settings.enableImageCompression
 					) {
-						buf = await this.compressImage(file);
+						// Convert to JPEG from PNG if the file has no transparency
+						let fileType = file.type;
+
+						// Reserve transparency, only convert to JPEG if the file has no transparency
+						if (fileType.startsWith("image/png") && !(await this.hasPngAlpha(file))) {
+							fileType = "image/jpeg";
+
+							// Update the file name to include the JPEG extension
+							newFileName = `${digest}.jpeg`;
+						}
+
+						buf = await this.compressImage(file, fileType);
 						file = new File([buf], newFileName, {
-							type: file.type,
+							type: fileType,
 						});
 					}
+
+					const key = folder ? `${folder}/${newFileName}` : newFileName;
 
 					if (!localUpload) {
 						url = await this.uploadFile(file, key);
@@ -572,7 +601,7 @@ export default class S3UploaderPlugin extends Plugin {
 		);
 	}
 
-	onunload() {}
+	onunload() { }
 
 	async loadSettings() {
 		this.settings = Object.assign(
@@ -1126,9 +1155,8 @@ class ObsHttpHandler extends FetchHttpHandler {
 		}
 
 		const { port, method } = request;
-		const url = `${request.protocol}//${request.hostname}${
-			port ? `:${port}` : ""
-		}${path}`;
+		const url = `${request.protocol}//${request.hostname}${port ? `:${port}` : ""
+			}${path}`;
 		const body =
 			method === "GET" || method === "HEAD" ? undefined : request.body;
 


### PR DESCRIPTION
- Use web worker to prevent hanging the main thread and app.
- Convert to JPEG from PNG automatically when there is no transparent pixel.
- Return original image when compressed image size is larger than original.